### PR TITLE
Fix debug mode flag in frontend auth config

### DIFF
--- a/drsearch_frontend/lib/auth.ts
+++ b/drsearch_frontend/lib/auth.ts
@@ -10,7 +10,10 @@ import { TokenSetParameters } from "openid-client";
 
 const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED !== 'False';
 const API_SCOPE = process.env.NEXT_PUBLIC_AZURE_AD_API_SCOPE; // Replace with your actual API scope
-const NEXT_AUTH_DEBUG_MODE = process.env.NEXTAUTH_DEBUG === 'true'; // Default debug mode to false if not set
+// Honour the NEXT_AUTH_DEBUG_MODE environment variable for enabling verbose
+// logging in NextAuth.
+const NEXT_AUTH_DEBUG_MODE =
+  process.env.NEXT_AUTH_DEBUG_MODE === 'true';
 
 
 console.log("Auth Enabled:", AUTH_ENABLED);


### PR DESCRIPTION
## Summary
- ensure frontend auth debug mode reads the correct NEXT_AUTH_DEBUG_MODE env var

## Testing
- `poetry run pytest -q` *(fails: Command not found)*