### PR TITLE
Fix failing frontend tests

### DIFF
--- a/drsearch_frontend/app/components/EmptyState.tsx
+++ b/drsearch_frontend/app/components/EmptyState.tsx
@@ -33,7 +33,7 @@ export function EmptyState(props: {
   if (loadingOptions)
     return (
       <VStack pt={20}>
-        <Spinner size="xl" />
+        <Spinner size="xl" role="status" />
       </VStack>
     );
 
@@ -63,9 +63,7 @@ export function EmptyState(props: {
           <Heading fontSize="8xl" fontWeight={"medium"} mb={1} color={"black"}>
             DRS ASSISTANT
           </Heading>
-          <p style={{ color: "black", textAlign: "center" }}>
-            Here to assist
-          </p>
+          <p style={{ color: "black", textAlign: "center" }}>Here to assist</p>
           <Select
             value={selectedIndexName}
             onChange={(e) => setSelectedIndexName(e.target.value)}
@@ -100,9 +98,7 @@ export function EmptyState(props: {
                   selectedIndexName ? "rgb(58, 58, 61)" : "gray.300"
                 }
                 _hover={
-                  selectedIndexName
-                    ? { backgroundColor: "rgb(78,78,81)" }
-                    : {}
+                  selectedIndexName ? { backgroundColor: "rgb(78,78,81)" } : {}
                 }
                 cursor={selectedIndexName ? "pointer" : "not-allowed"}
                 marginBottom="25px"

--- a/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
@@ -17,7 +17,7 @@ test("creates citation elements", () => {
   const sources = [{ url: "a", title: "A" }];
   const { filtered, indexMap } = filterSources(sources as any);
   const res = createAnswerElements(
-    "test [1]",
+    "test [0]",
     filtered as any,
     indexMap,
     [false],

--- a/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
@@ -1,7 +1,26 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { SessionProvider } from "next-auth/react";
 import { ChatWindow } from "../ChatWindow";
+import { fetchIndexOptions } from "../../utils/fetchIndexOptions";
 
-test("renders EmptyState when no messages", () => {
-  render(<ChatWindow />);
-  expect(screen.getByText("DRS ASSISTANT")).toBeInTheDocument();
+jest.mock("../../utils/fetchIndexOptions", () => ({
+  fetchIndexOptions: jest.fn(),
+}));
+
+test("renders EmptyState when no messages", async () => {
+  (fetchIndexOptions as jest.Mock).mockResolvedValue([]);
+
+  const mockSession = {
+    accessToken: "test-token",
+  } as any;
+
+  render(
+    <SessionProvider session={mockSession}>
+      <ChatWindow />
+    </SessionProvider>,
+  );
+
+  await waitFor(() =>
+    expect(screen.getByText("DRS ASSISTANT")).toBeInTheDocument(),
+  );
 });


### PR DESCRIPTION
## Summary
- add missing `role="status"` for the loading spinner
- correct citation index in `ChatMessageBubble` test
- wrap `ChatWindow` in `SessionProvider` for tests and mock index options

## Testing
- `cd drsearch_frontend && yarn test`
