### PR TITLE
Add thorough frontend unit tests

### DIFF
--- a/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
@@ -26,3 +26,44 @@ test("creates citation elements", () => {
   const { container } = render(<>{res}</>);
   expect(container.querySelector("a")).toBeTruthy();
 });
+import { screen, fireEvent } from "@testing-library/react";
+import { ChatMessageBubble } from "../ChatMessageBubble";
+import { sendFeedback } from "../../utils/sendFeedback";
+import { useSession } from "next-auth/react";
+
+jest.mock("../../utils/sendFeedback");
+jest.mock("next-auth/react");
+
+beforeEach(() => {
+  (useSession as jest.Mock).mockReturnValue({ data: { accessToken: "t" } });
+});
+
+test("renders user message", () => {
+  render(
+    <ChatMessageBubble
+      message={{ id: "1", content: "hi", role: "user" }}
+      isMostRecent={false}
+      messageCompleted
+    />,
+  );
+  expect(screen.getByText("hi")).toBeInTheDocument();
+});
+
+test("assistant feedback buttons trigger sendFeedback", () => {
+  (sendFeedback as jest.Mock).mockResolvedValue({ code: 200, feedbackId: "f" });
+  render(
+    <ChatMessageBubble
+      message={{
+        id: "2",
+        content: "answer",
+        role: "assistant",
+        runId: "r",
+        sources: [],
+      }}
+      isMostRecent
+      messageCompleted
+    />,
+  );
+  fireEvent.click(screen.getByText("👍"));
+  expect(sendFeedback).toHaveBeenCalled();
+});

--- a/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
@@ -24,3 +24,39 @@ test("renders EmptyState when no messages", async () => {
     expect(screen.getByText("DRS ASSISTANT")).toBeInTheDocument(),
   );
 });
+import { fireEvent } from "@testing-library/react";
+import { fetchEventSource } from "@microsoft/fetch-event-source";
+
+jest.mock("@microsoft/fetch-event-source", () => ({
+  fetchEventSource: jest.fn(() => Promise.resolve()),
+}));
+
+test("shows options and sends initial question", async () => {
+  (fetchIndexOptions as jest.Mock).mockResolvedValue([
+    { name: "idx", display_name: "Index", example_questions: ["q1"] },
+  ]);
+  const mockSession = { accessToken: "token" } as any;
+  render(
+    <SessionProvider session={mockSession}>
+      <ChatWindow />
+    </SessionProvider>,
+  );
+  await screen.findByText("Select Document Index");
+  const select = screen.getByRole("combobox");
+  fireEvent.change(select, { target: { value: "idx" } });
+  fireEvent.mouseUp(screen.getByText("q1"));
+  expect(fetchEventSource).toHaveBeenCalled();
+  expect(screen.queryByText("q1")).not.toBeNull();
+});
+
+test("send button disabled without index", async () => {
+  (fetchIndexOptions as jest.Mock).mockResolvedValue([]);
+  const mockSession = { accessToken: "token" } as any;
+  render(
+    <SessionProvider session={mockSession}>
+      <ChatWindow />
+    </SessionProvider>,
+  );
+  await screen.findByText("DRS ASSISTANT");
+  expect(screen.getByLabelText("Send")).toBeDisabled();
+});

--- a/drsearch_frontend/app/components/__tests__/SourceBubble.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/SourceBubble.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { SourceBubble } from "../SourceBubble";
+import { sendFeedback } from "../../utils/sendFeedback";
+
+jest.mock("../../utils/sendFeedback");
 
 const source = { url: "http://example.com", title: "Example" };
 
@@ -31,4 +34,25 @@ test("calls handlers on hover", () => {
   fireEvent.mouseLeave(card!);
   expect(enter).toHaveBeenCalled();
   expect(leave).toHaveBeenCalled();
+});
+
+test("sends feedback on click", async () => {
+  (sendFeedback as jest.Mock).mockResolvedValue({});
+  render(
+    <SourceBubble
+      source={source}
+      highlighted={false}
+      onMouseEnter={() => {}}
+      onMouseLeave={() => {}}
+      runId="123"
+    />,
+  );
+  const card = screen.getByText("Example").closest("div") as HTMLElement;
+  fireEvent.click(card!);
+  expect(sendFeedback).toHaveBeenCalledWith({
+    key: "user_click",
+    runId: "123",
+    value: source.url,
+    isExplicit: false,
+  });
 });

--- a/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
@@ -1,6 +1,6 @@
 import { fetchIndexOptions } from "../fetchIndexOptions";
 
-const apiUrl = "http://localhost:8010/index-options";
+const apiUrl = "http://localhost:8011/index-options";
 
 beforeEach(() => {
   (global.fetch as any) = jest.fn();

--- a/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
@@ -1,0 +1,45 @@
+import { fetchIndexOptions } from "../fetchIndexOptions";
+
+const apiUrl = "http://localhost:8010/index-options";
+
+beforeEach(() => {
+  (global.fetch as any) = jest.fn();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test("fetches index options with token", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ code: 200, result: [{ name: "a" }] }),
+  });
+  const res = await fetchIndexOptions("tok");
+  expect(fetch).toHaveBeenCalledWith(apiUrl, {
+    headers: { Authorization: "Bearer tok" },
+  });
+  expect(res).toEqual([{ name: "a" }]);
+});
+
+test("throws error on http failure", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status: 500,
+    text: () => Promise.resolve("fail"),
+    statusText: "error",
+  });
+  await expect(fetchIndexOptions()).rejects.toThrow(
+    "Failed to fetch index options: 500 – fail",
+  );
+});
+
+test("throws error on malformed data", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ code: 400, result: null }),
+  });
+  await expect(fetchIndexOptions()).rejects.toThrow(
+    "Backend returned malformed data",
+  );
+});

--- a/drsearch_frontend/app/utils/__tests__/sendFeedback.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/sendFeedback.test.ts
@@ -1,0 +1,52 @@
+import { sendFeedback } from "../sendFeedback";
+import { apiBaseUrl } from "../constants";
+import { v4 as uuidv4 } from "uuid";
+
+jest.mock("uuid");
+
+beforeEach(() => {
+  (global.fetch as any) = jest.fn();
+  (uuidv4 as jest.Mock).mockReturnValue("uuid");
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test("posts feedback when no id provided", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    json: () => Promise.resolve({ code: 200, result: "ok" }),
+  });
+  const res = await sendFeedback({
+    key: "k",
+    runId: "r",
+    score: 1,
+    value: "v",
+    comment: "c",
+    isExplicit: true,
+  });
+  expect(fetch).toHaveBeenCalledWith(
+    apiBaseUrl + "/feedback",
+    expect.objectContaining({ method: "POST" }),
+  );
+  const body = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+  expect(body.key).toBe("k");
+  expect(res).toEqual({ code: 200, result: "ok", feedbackId: "uuid" });
+});
+
+test("patches feedback when id provided", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    json: () => Promise.resolve({ code: 200, result: "ok" }),
+  });
+  const res = await sendFeedback({
+    key: "k",
+    runId: "r",
+    feedbackId: "f",
+    isExplicit: false,
+  });
+  expect(fetch).toHaveBeenCalledWith(
+    apiBaseUrl + "/feedback",
+    expect.objectContaining({ method: "PATCH" }),
+  );
+  expect(res.feedbackId).toBe("f");
+});

--- a/drsearch_frontend/app/utils/__tests__/urlUtils.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/urlUtils.test.ts
@@ -1,0 +1,12 @@
+import { convertToHttpUrlIfNeeded } from "../urlUtils";
+
+test("converts UNC path to http url", () => {
+  const unc = "\\\\home.drs.com@ssl\\DavWWWRoot\\folder\\My File.txt";
+  const expected = "https://home.drs.com/folder/My%20File.txt?web=1";
+  expect(convertToHttpUrlIfNeeded(unc)).toBe(expected);
+});
+
+test("returns original string when pattern not matched", () => {
+  const path = "/some/other/path.txt";
+  expect(convertToHttpUrlIfNeeded(path)).toBe(path);
+});


### PR DESCRIPTION
## Summary
- increase coverage for frontend utils and components
- add tests for fetchIndexOptions, sendFeedback and urlUtils
- test additional component behaviors for ChatWindow, ChatMessageBubble and SourceBubble

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `yarn lint`
- `yarn format`
- `yarn test --coverage`
