### PR TITLE
Improve ChatMessageBubble test coverage

### DIFF
--- a/drsearch_frontend/app/components/ChatMessageBubble.tsx
+++ b/drsearch_frontend/app/components/ChatMessageBubble.tsx
@@ -21,6 +21,16 @@ import { apiBaseUrl } from "../utils/constants";
 import { InlineCitation } from "./InlineCitation";
 import DOMPurify from "dompurify";
 
+export const __TEST__ = {
+  sendUserFeedback: null as
+    | ((score: number, key: string) => Promise<void>)
+    | null,
+  animateButton: null as ((buttonId: string) => void) | null,
+  viewTrace: null as (() => Promise<void>) | null,
+  setComment: null as ((c: string) => void) | null,
+  comment: "",
+};
+
 export type Message = {
   id: string;
   createdAt?: Date;
@@ -155,6 +165,8 @@ export function ChatMessageBubble(props: {
   const [traceIsLoading, setTraceIsLoading] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [comment, setComment] = useState("");
+  __TEST__.setComment = setComment;
+  __TEST__.comment = comment;
   const [feedbackColor, setFeedbackColor] = useState("");
   const upButtonRef = useRef(null);
   const downButtonRef = useRef(null);
@@ -209,14 +221,15 @@ export function ChatMessageBubble(props: {
         }
         console.log("Feedback sent successfully:", data);
       }
-      } catch (e: any) {
-        /* istanbul ignore next */
-        console.error("Error sending feedback:", e);
-        /* istanbul ignore next */
-        toast.error(e.message);
+    } catch (e: any) {
+      /* istanbul ignore next */
+      console.error("Error sending feedback:", e);
+      /* istanbul ignore next */
+      toast.error(e.message);
     }
     setIsLoading(false);
   };
+  __TEST__.sendUserFeedback = sendUserFeedback;
 
   const viewTrace = async () => {
     console.log("Viewing trace for run ID:", runId);
@@ -250,6 +263,7 @@ export function ChatMessageBubble(props: {
       toast.error(e.message);
     }
   };
+  __TEST__.viewTrace = viewTrace;
 
   const sources = props.message.sources ?? [];
   const { filtered: filteredSources, indexMap: sourceIndexMap } =
@@ -305,6 +319,7 @@ export function ChatMessageBubble(props: {
     });
     console.log("Button animation completed for:", buttonId);
   };
+  __TEST__.animateButton = animateButton;
 
   return (
     <VStack align="start" spacing={5} pb={5}>

--- a/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
@@ -1,25 +1,26 @@
 // app/components/__tests__/ChatMessageBubble.test.tsx
 import React from "react";
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor
-} from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import {
   filterSources,
   createAnswerElements,
-  ChatMessageBubble
+  ChatMessageBubble,
+  __TEST__,
 } from "../ChatMessageBubble";
 import { sendFeedback } from "../../utils/sendFeedback";
 import { SessionProvider, useSession } from "next-auth/react";
 import { ChakraProvider } from "@chakra-ui/react";
+import { emojisplosion } from "emojisplosion";
+
+jest.mock("emojisplosion", () => ({ emojisplosion: jest.fn() }));
 
 jest.mock("../../utils/sendFeedback");
 jest.mock("next-auth/react", () => ({
   __esModule: true,
   // preserve actual named export SessionProvider but ensure it renders children
-  SessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SessionProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
   useSession: jest.fn(),
 }));
 
@@ -27,12 +28,12 @@ const renderWithProviders = (ui: React.ReactElement) =>
   render(
     <ChakraProvider>
       <SessionProvider session={null}>{ui}</SessionProvider>
-    </ChakraProvider>
+    </ChakraProvider>,
   );
 
 beforeEach(() => {
   (useSession as jest.Mock).mockReturnValue({
-    data: { accessToken: "t" }
+    data: { accessToken: "t" },
   });
   jest.clearAllMocks();
 });
@@ -42,7 +43,7 @@ describe("utility functions", () => {
     const sources = [
       { url: "a", title: "A" },
       { url: "a", title: "A2" },
-      { url: "b", title: "B" }
+      { url: "b", title: "B" },
     ];
     const { filtered, indexMap } = filterSources(sources as any);
     expect(filtered).toHaveLength(2);
@@ -67,7 +68,7 @@ describe("utility functions", () => {
       filtered as any,
       indexMap,
       [false],
-      setHighlight
+      setHighlight,
     );
     const { container } = render(<>{elements}</>);
     const link = container.querySelector("a")!;
@@ -86,7 +87,7 @@ describe("ChatMessageBubble component", () => {
         message={{ id: "1", content: "hi", role: "user" }}
         isMostRecent={false}
         messageCompleted
-      />
+      />,
     );
     expect(container.innerHTML).toContain("hi");
   });
@@ -95,7 +96,7 @@ describe("ChatMessageBubble component", () => {
     jest.useFakeTimers();
     (sendFeedback as jest.Mock).mockResolvedValue({
       code: 200,
-      feedbackId: "f"
+      feedbackId: "f",
     });
 
     renderWithProviders(
@@ -105,11 +106,11 @@ describe("ChatMessageBubble component", () => {
           content: "answer",
           role: "assistant",
           runId: "r",
-          sources: []
+          sources: [],
         }}
         isMostRecent
         messageCompleted
-      />
+      />,
     );
 
     // first button is 👍
@@ -123,17 +124,26 @@ describe("ChatMessageBubble component", () => {
         expect.objectContaining({
           score: 1,
           runId: "r",
-          key: "user_score"
-        })
+          key: "user_score",
+        }),
       );
     });
   });
 
   test("downvote button also sends feedback", async () => {
-    (sendFeedback as jest.Mock).mockResolvedValue({ code: 200, feedbackId: "d" });
+    (sendFeedback as jest.Mock).mockResolvedValue({
+      code: 200,
+      feedbackId: "d",
+    });
     renderWithProviders(
       <ChatMessageBubble
-        message={{ id: "x", content: "a", role: "assistant", runId: "r", sources: [] }}
+        message={{
+          id: "x",
+          content: "a",
+          role: "assistant",
+          runId: "r",
+          sources: [],
+        }}
         isMostRecent
         messageCompleted
       />,
@@ -149,7 +159,7 @@ describe("ChatMessageBubble component", () => {
         message={{ id: "3", content: "hi", role: "assistant" }}
         isMostRecent
         messageCompleted
-      />
+      />,
     );
     fireEvent.click(screen.getAllByRole("button")[0]);
     expect(sendFeedback).not.toHaveBeenCalled();
@@ -160,7 +170,7 @@ describe("ChatMessageBubble component", () => {
     (sendFeedback as jest.Mock).mockReturnValue(
       new Promise((r) => {
         resolve = r;
-      })
+      }),
     );
     renderWithProviders(
       <ChatMessageBubble
@@ -169,11 +179,11 @@ describe("ChatMessageBubble component", () => {
           content: "answer",
           role: "assistant",
           runId: "r",
-          sources: []
+          sources: [],
         }}
         isMostRecent
         messageCompleted
-      />
+      />,
     );
     const btn = screen.getAllByRole("button")[0];
     fireEvent.click(btn);
@@ -184,7 +194,7 @@ describe("ChatMessageBubble component", () => {
 
   test("view trace button opens url", async () => {
     (global as any).fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve('"http://x"') })
+      Promise.resolve({ json: () => Promise.resolve('"http://x"') }),
     );
     const open = (window.open = jest.fn());
     renderWithProviders(
@@ -194,11 +204,11 @@ describe("ChatMessageBubble component", () => {
           content: "answer",
           role: "assistant",
           runId: "r",
-          sources: []
+          sources: [],
         }}
         isMostRecent
         messageCompleted
-      />
+      />,
     );
     fireEvent.click(screen.getByText(/view trace/i));
     await waitFor(() => expect(open).toHaveBeenCalled());
@@ -206,7 +216,7 @@ describe("ChatMessageBubble component", () => {
 
   test("view trace shows error", async () => {
     (global as any).fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve({ code: 400 }) })
+      Promise.resolve({ json: () => Promise.resolve({ code: 400 }) }),
     );
     const open = (window.open = jest.fn());
     renderWithProviders(
@@ -216,11 +226,11 @@ describe("ChatMessageBubble component", () => {
           content: "answer",
           role: "assistant",
           runId: "r",
-          sources: []
+          sources: [],
         }}
         isMostRecent
         messageCompleted
-      />
+      />,
     );
     fireEvent.click(screen.getByText(/view trace/i));
     await waitFor(() => expect(open).not.toHaveBeenCalled());
@@ -243,5 +253,103 @@ describe("ChatMessageBubble component", () => {
     const bubble = screen.getByText("Title");
     fireEvent.mouseEnter(bubble);
     fireEvent.mouseLeave(bubble);
+  });
+
+  test("citation fallback uses last source", () => {
+    const sources = Array.from({ length: 11 }, (_, i) => ({
+      url: `u${i}`,
+      title: `t${i}`,
+    }));
+    const elements = createAnswerElements(
+      "hi [5] there",
+      sources as any,
+      new Map(),
+      new Array(11).fill(false),
+      jest.fn(),
+    );
+    const { container } = render(<>{elements}</>);
+    const link = container.querySelector("a")!;
+    expect(link).toHaveAttribute("href", "u10");
+    expect(link.textContent).toBe("6");
+  });
+
+  test("sendUserFeedback early returns", async () => {
+    renderWithProviders(
+      <ChatMessageBubble
+        message={{ id: "e", content: "a", role: "assistant" }}
+        isMostRecent
+        messageCompleted
+      />,
+    );
+    await (__TEST__.sendUserFeedback as any)(1, "user_score");
+    expect(sendFeedback).not.toHaveBeenCalled();
+  });
+
+  test("comment resets after feedback", async () => {
+    (sendFeedback as jest.Mock).mockResolvedValue({
+      code: 200,
+      feedbackId: "f",
+    });
+    renderWithProviders(
+      <ChatMessageBubble
+        message={{ id: "c", content: "a", role: "assistant", runId: "r" }}
+        isMostRecent
+        messageCompleted
+      />,
+    );
+    (__TEST__.setComment as any)("note");
+    await (__TEST__.sendUserFeedback as any)(1, "user_score");
+    await waitFor(() => expect(__TEST__.comment).toBe(""));
+  });
+
+  test("animateButton default branch", () => {
+    renderWithProviders(
+      <ChatMessageBubble
+        message={{ id: "b", content: "a", role: "assistant", runId: "r" }}
+        isMostRecent
+        messageCompleted
+      />,
+    );
+    (__TEST__.animateButton as any)("unknown");
+    expect(emojisplosion).not.toHaveBeenCalled();
+  });
+
+  test("post feedback clicks and trace error flow", async () => {
+    jest.useRealTimers();
+    (sendFeedback as jest.Mock).mockResolvedValue({
+      code: 200,
+      feedbackId: "1",
+    });
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({ code: 400 }) }),
+    );
+    const toast = require("react-toastify").toast;
+    const err = jest.spyOn(toast, "error").mockImplementation(() => {});
+    renderWithProviders(
+      <ChatMessageBubble
+        message={{
+          id: "z",
+          content: "a",
+          role: "assistant",
+          runId: "r",
+          sources: [],
+        }}
+        isMostRecent
+        messageCompleted
+      />,
+    );
+    const [up] = screen.getAllByRole("button");
+    fireEvent.click(up);
+    await waitFor(() => expect(sendFeedback).toHaveBeenCalledTimes(1));
+    await new Promise((r) => setTimeout(r, 0));
+    fireEvent.click(up);
+    expect(err).toHaveBeenCalledWith(
+      "You have already provided your feedback.",
+    );
+    await (__TEST__.viewTrace as any)();
+    await waitFor(() =>
+      expect(err).toHaveBeenCalledWith("Unable to view trace"),
+    );
+    err.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- expose internal functions for testing
- add tests for fallback citations, early return, comment reset
- cover animation default branch and feedback flow with trace error

## Testing
- `yarn lint`
- `yarn test`