### PR TITLE
Add error message coverage for fetchIndexOptions

### DIFF
--- a/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
@@ -34,6 +34,18 @@ test("throws error on http failure", async () => {
   );
 });
 
+test("uses statusText when error body empty", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status: 404,
+    text: () => Promise.resolve(""),
+    statusText: "Not Found",
+  });
+  await expect(fetchIndexOptions()).rejects.toThrow(
+    "Failed to fetch index options: 404 – Not Found",
+  );
+});
+
 test("throws error on malformed data", async () => {
   (fetch as jest.Mock).mockResolvedValue({
     ok: true,


### PR DESCRIPTION
## Summary
- extend tests for `fetchIndexOptions` to cover error fallback logic

## Testing
- `yarn lint`
- `yarn format`
- `yarn test`
- `poetry run pytest --cov=app --cov-report=term-missing -q`