### PR TITLE
Fix RAG OFF mode not requiring DB

### DIFF
--- a/drsearch_backend/app/core/chain_config.py
+++ b/drsearch_backend/app/core/chain_config.py
@@ -7,7 +7,7 @@ Chain-specific environment setup and constants for DRSearch’s RAG/chat pipelin
 import os
 from pathlib import Path
 
-import truststore   # ensure OS-level CA store is honoured
+import truststore  # ensure OS-level CA store is honoured
 from dotenv import load_dotenv
 
 # ─── Environment bootstrapping ────────────────────────────────────────────────
@@ -21,7 +21,7 @@ load_dotenv()
 # ─── Chain constants ─────────────────────────────────────────────────────────
 
 #: Toggle RAG vs. plain-chatbot mode
-RAG_ON: bool = True
+RAG_ON: bool = os.getenv("RAG_ON", "True").lower() == "true"
 
 #: How many documents to pull per query when RAG_ON
 _NUMBER_OF_DOCS_RETRIEVED: int = 3
@@ -30,8 +30,12 @@ _NUMBER_OF_DOCS_RETRIEVED: int = 3
 _DEFAULT_INDEX: str = "JACSKE_Program"
 
 #: Weaviate connection settings
-_WEAVIATE_URL: str = os.environ["WEAVIATE_URL"]
-_WEAVIATE_API_KEY: str = os.environ["WEAVIATE_API_KEY"]
+if RAG_ON:
+    _WEAVIATE_URL: str = os.environ["WEAVIATE_URL"]
+    _WEAVIATE_API_KEY: str = os.environ["WEAVIATE_API_KEY"]
+else:  # Database details optional when RAG disabled
+    _WEAVIATE_URL = os.getenv("WEAVIATE_URL", "")
+    _WEAVIATE_API_KEY = os.getenv("WEAVIATE_API_KEY", "")
 
 #: Whether Auth is enabled (True/False)
 _AUTH_ENABLED: bool = os.getenv("AUTH_ENABLED", "True") == "True"

--- a/drsearch_backend/tests/conftest.py
+++ b/drsearch_backend/tests/conftest.py
@@ -19,6 +19,8 @@ _DUMMY_ENV: Dict[str, str] = {
     "AZURE_OPENAI_DEPLOYMENT_NAME": "dummy-model",
     "AZURE_OPENAI_ENDPOINT": "https://dummy-endpoint.openai.azure.com/",
     "AZURE_OPENAI_API_KEY": "dummy-key",
+    # RAG is enabled by default during tests
+    "RAG_ON": "True",
     # Auth (turned OFF for most tests – can be re-enabled where needed)
     "AUTH_ENABLED": "False",
     "CORS_ORIGINS": "http://localhost",

--- a/drsearch_backend/tests/test_chat_engine.py
+++ b/drsearch_backend/tests/test_chat_engine.py
@@ -11,8 +11,8 @@ class DummyLLM:
     def __call__(self, input, **kwargs):
         return "LLM-OK"
 
-dummy_llm = RunnableLambda(DummyLLM())
 
+dummy_llm = RunnableLambda(DummyLLM())
 
 
 def test_chat_engine_unknown_index():
@@ -23,6 +23,7 @@ def test_chat_engine_unknown_index():
 def test_chat_engine_answer_chain_simple_RAG_OFF(monkeypatch):
     # Force RAG mode off so retriever chain is skipped -> simpler test
     monkeypatch.setattr("app.chain.engine.RAG_ON", False)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", False)
 
     eng = ChatEngine()  # default index
 
@@ -37,6 +38,7 @@ def test_chat_engine_answer_chain_simple_RAG_ON(monkeypatch):
     """Full RAG chain incl. MultiQueryRetriever should succeed with FakeListLLM."""
 
     monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
 
     # Ensure retriever chain uses a predictable in-memory retriever instead of
     # the real Weaviate vector-store, which is outside the scope of unit tests.
@@ -65,6 +67,7 @@ def test_llm_init_failure(monkeypatch):
     with pytest.raises(RuntimeError, match="boom"):
         ChatEngine("JACSKE_Program")  # any valid key from INDEX_CONFIG
 
+
 def test_multiquery_retriever_path(monkeypatch):
     from app.chain.engine import ChatEngine
 
@@ -73,6 +76,9 @@ def test_multiquery_retriever_path(monkeypatch):
         lambda *_, **__: _DummyRetriever(),
     )
 
+    monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
+
     monkeypatch.setattr(
         "app.chain.engine.AzureChatOpenAI",
         lambda *_, **__: _fake_llm_for_answer("LLM-OK"),
@@ -80,13 +86,17 @@ def test_multiquery_retriever_path(monkeypatch):
 
     ChatEngine("JACSKE_Program")  # should initialise without error
 
+
 def test_context_map_with_retriever(monkeypatch):
     monkeypatch.setattr(
         "app.chain.engine.AzureChatOpenAI",
         lambda *_, **__: _fake_llm_for_answer("answer"),
     )
+    monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
 
     from tests.conftest import _DummyRetriever  # type: ignore
+
     monkeypatch.setattr(
         "app.chain.retriever.RetrieverFactory.build",
         lambda *_, **__: _DummyRetriever(),
@@ -96,7 +106,6 @@ def test_context_map_with_retriever(monkeypatch):
 
     result = engine.answer_chain.invoke({"question": "test?", "chat_history": []})
     assert "answer" in result
-
 
 
 def test_modify_docs_enriches_path(monkeypatch, tmp_path):
@@ -120,8 +129,9 @@ def test_modify_docs_enriches_path(monkeypatch, tmp_path):
 
     engine = ChatEngine("JACSKE_Program")
 
-    retriever = RunnableLambda(lambda input: [Document(page_content="...", metadata={"filename": "abc.pdf"})])
-
+    retriever = RunnableLambda(
+        lambda input: [Document(page_content="...", metadata={"filename": "abc.pdf"})]
+    )
 
     format_fn = lambda docs: "<doc>content</doc>"
 
@@ -144,6 +154,7 @@ def _fake_llm_for_answer(final_answer: str) -> FakeListLLM:
 def _dup_test_chat_engine_answer_chain_simple_RAG_ON_fake(monkeypatch):
     # Force RAG mode off so retriever chain is skipped -> simpler test
     monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
 
     # Use a FakeListLLM that returns predictable values for MultiQueryRetriever.
     monkeypatch.setattr(
@@ -168,6 +179,8 @@ def _dup_test_multiquery_retriever_path_fake(monkeypatch):
         "app.chain.engine.AzureChatOpenAI",
         lambda *_, **__: _fake_llm_for_answer("LLM-OK"),
     )
+    monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
 
     ChatEngine("JACSKE_Program")  # this will now succeed
 
@@ -177,13 +190,17 @@ def _dup_test_context_map_with_retriever_fake(monkeypatch):
         "app.chain.engine.AzureChatOpenAI",
         lambda *_, **__: _fake_llm_for_answer("answer"),
     )
+    monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
 
     engine = ChatEngine("JACSKE_Program")
 
-    result = engine.answer_chain.invoke({
-        "question": "test?",
-        "chat_history": [],
-    })
+    result = engine.answer_chain.invoke(
+        {
+            "question": "test?",
+            "chat_history": [],
+        }
+    )
     assert "answer" in result
 
 
@@ -201,6 +218,9 @@ def _dup_test_modify_docs_enriches_path_fake(monkeypatch, tmp_path):
         lambda *_, **__: _DummyRetriever(),
     )
 
+    monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
+
     monkeypatch.setattr(
         "app.chain.engine.AzureChatOpenAI",
         lambda *_, **__: _fake_llm_for_answer("LLM-OK"),
@@ -208,8 +228,9 @@ def _dup_test_modify_docs_enriches_path_fake(monkeypatch, tmp_path):
 
     engine = ChatEngine("JACSKE_Program")
 
-    retriever = RunnableLambda(lambda input: [Document(page_content="...", metadata={"filename": "abc.pdf"})])
-
+    retriever = RunnableLambda(
+        lambda input: [Document(page_content="...", metadata={"filename": "abc.pdf"})]
+    )
 
     format_fn = lambda docs: "<doc>content</doc>"
 

--- a/drsearch_backend/tests/test_extra_coverage.py
+++ b/drsearch_backend/tests/test_extra_coverage.py
@@ -55,7 +55,9 @@ def test_cli_interactive_exit(monkeypatch, capsys):
     monkeypatch.setattr(builtins, "input", lambda _p="": next(user_inputs))
 
     # The stub engine will echo back "stub-response" so the AI path is taken.
-    monkeypatch.setattr("app.chain.cli._engine_for", lambda idx: _StubEngine("stub-response"))
+    monkeypatch.setattr(
+        "app.chain.cli._engine_for", lambda idx: _StubEngine("stub-response")
+    )
 
     chain_cli()
 
@@ -73,7 +75,9 @@ def test_mapping_no_file(tmp_path):
 
 def test_models_chat_request():
     """Ensure the Pydantic model validates and serialises as expected."""
-    req = ChatRequest(question="q", chat_history=[{"human": "h", "ai": "a"}], index_name="idx")
+    req = ChatRequest(
+        question="q", chat_history=[{"human": "h", "ai": "a"}], index_name="idx"
+    )
     data = req.dict()
     assert data["question"] == "q"
     assert data["chat_history"][0]["human"] == "h"
@@ -85,7 +89,9 @@ def test_settings_split_origins():
     # Ensure any existing env-var does not interfere with constructor-provided value
     os.environ.pop("CORS_ORIGINS", None)
 
-    cfg = Settings(cors_origins="http://a.com , http://b.com", tenant_id="t", client_id="c")
+    cfg = Settings(
+        cors_origins="http://a.com , http://b.com", tenant_id="t", client_id="c"
+    )
     assert cfg.cors_origins == ["http://a.com", "http://b.com"]
 
 
@@ -94,7 +100,9 @@ def test_index_options_structure():
     assert isinstance(INDEX_OPTIONS, list) and INDEX_OPTIONS, "Empty index options list"
     for item in INDEX_OPTIONS:
         assert {"name", "display_name", "example_questions"}.issubset(item)
-        assert isinstance(item["example_questions"], list) and item["example_questions"], "Missing questions"
+        assert (
+            isinstance(item["example_questions"], list) and item["example_questions"]
+        ), "Missing questions"
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -115,7 +123,11 @@ def test_main_module_execution(monkeypatch):
     monkeypatch.setattr("uvicorn.Config", lambda *a, **k: object())
 
     # Prevent real signal handling on non-main threads / platforms
-    monkeypatch.setattr("asyncio.AbstractEventLoop.add_signal_handler", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(
+        "asyncio.AbstractEventLoop.add_signal_handler",
+        lambda *a, **k: None,
+        raising=False,
+    )
 
     # Replace asyncio.new_event_loop with a dummy loop that has the required methods.
     import asyncio
@@ -131,7 +143,7 @@ def test_main_module_execution(monkeypatch):
     monkeypatch.setattr(asyncio, "set_event_loop", lambda *a, **k: None)
 
     # Provide a valid CORS_ORIGINS so Settings() validates successfully
-    monkeypatch.setenv("CORS_ORIGINS","http://localhost:3000")
+    monkeypatch.setenv("CORS_ORIGINS", "http://localhost:3000")
 
     # Finally run the module as if it were the main program. The patched pieces
     # ensure nothing heavyweight actually happens.
@@ -146,15 +158,23 @@ def test_engine_modify_docs_mapping_none(monkeypatch):
 
     # Force RAG_ON so retriever logic is active but patch everything heavy.
     monkeypatch.setattr("app.chain.engine.RAG_ON", True)
-    monkeypatch.setattr("app.chain.retriever.RetrieverFactory.build", lambda *_, **__: _DummyRetriever())
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
+    monkeypatch.setattr(
+        "app.chain.retriever.RetrieverFactory.build", lambda *_, **__: _DummyRetriever()
+    )
 
     # Lightweight LLM replacement
-    monkeypatch.setattr("app.chain.engine.AzureChatOpenAI", lambda *_, **__: RunnableLambda(lambda *_a, **_k: "text"))
+    monkeypatch.setattr(
+        "app.chain.engine.AzureChatOpenAI",
+        lambda *_, **__: RunnableLambda(lambda *_a, **_k: "text"),
+    )
 
     eng = ChatEngine("SEPs_F_T_C_W_A_V")  # This index has PN_TO_FILE_MAPPING = None
 
     # Simple retriever returning a doc without file_path metadata.
-    retr = RunnableLambda(lambda q: [Document(page_content="x", metadata={"filename": "ignored.pdf"})])
+    retr = RunnableLambda(
+        lambda q: [Document(page_content="x", metadata={"filename": "ignored.pdf"})]
+    )
 
     chain = eng._build_retriever_chain(retr, lambda d: "")
     docs = chain.invoke({"question": "hi", "chat_history": []})
@@ -187,4 +207,4 @@ def test_cli_keyboard_interrupt(monkeypatch, capsys):
     chain_cli()
 
     captured = capsys.readouterr()
-    assert "Exiting." in captured.out 
+    assert "Exiting." in captured.out


### PR DESCRIPTION
## Summary
- guard Weaviate env vars behind RAG_ON check
- enable RAG by default in tests
- patch tests to update both engine and chain config flags

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`