### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -90,7 +90,11 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
     @router.get("/files/{file_path:path}")
     async def read_file(file_path: str) -> FileResponse:  # noqa: D401
         decoded = urllib.parse.unquote(file_path)
-        unc_path = decoded.replace("/", "\\")  # UNC path on Windows share
+        unc_path = os.path.normpath(os.path.join(BASE_DIR, decoded))  # Normalize path
+
+        if not unc_path.startswith(str(BASE_DIR)):
+            logger.warning("Unauthorized file access attempt", extra={"path": unc_path})
+            raise HTTPException(status_code=403, detail="Access to the requested file is forbidden")
 
         if not os.path.exists(unc_path):
             logger.info("File not found", extra={"path": unc_path})


### PR DESCRIPTION
Potential fix for [https://github.com/BakedChicken77/DRSearch/security/code-scanning/2](https://github.com/BakedChicken77/DRSearch/security/code-scanning/2)

To fix the issue, we need to ensure that the constructed file path (`unc_path`) is validated against a safe root directory. This can be achieved by:
1. Defining a safe base directory (e.g., `BASE_DIR` or a specific subdirectory for files).
2. Normalizing the constructed path using `os.path.normpath` to eliminate any `..` segments or other path traversal attempts.
3. Verifying that the normalized path starts with the safe base directory to ensure it does not escape the allowed directory.

The fix will involve:
- Adding a base directory for file storage (e.g., `SAFE_BASE_DIR`).
- Normalizing the `unc_path` using `os.path.normpath`.
- Checking that the normalized path starts with the safe base directory before serving the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
