### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/drsearch_backend/app/auth/middleware.py
+++ b/drsearch_backend/app/auth/middleware.py
@@ -87,7 +87,8 @@ class AuthMiddleware:
                 jwks_uri=self._oidc_config["jwks_uri"],
             )
         except TokenValidationError as exc:
-            resp = JSONResponse({"detail": str(exc)}, status_code=401)
+            logger.error("Token validation failed", exc_info=exc)
+            resp = JSONResponse({"detail": "Invalid token"}, status_code=401)
             await resp(scope, receive, send)
             return
 

--- a/drsearch_backend/tests/test_auth_middleware.py
+++ b/drsearch_backend/tests/test_auth_middleware.py
@@ -162,4 +162,4 @@ def test_invalid_token_rejected(monkeypatch):
     client = TestClient(app)
     r = client.get("/secure", headers={"Authorization": "Bearer fake.jwt.token"})
     assert r.status_code == 401
-    assert "bad signature" in r.json()["detail"]
+    assert "Invalid token" in r.json()["detail"]


### PR DESCRIPTION
Potential fix for [https://github.com/BakedChicken77/DRSearch/security/code-scanning/3](https://github.com/BakedChicken77/DRSearch/security/code-scanning/3)

To fix the issue, we will replace the detailed error message in the response with a generic message such as `"Invalid token"`. The detailed exception information (`exc`) will be logged using the `logger` object to ensure that developers can still access it for debugging purposes. This approach prevents sensitive information from being exposed to external users while retaining the ability to diagnose issues internally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
