### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -90,7 +90,11 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
     @router.get("/files/{file_path:path}")
     async def read_file(file_path: str) -> FileResponse:  # noqa: D401
         decoded = urllib.parse.unquote(file_path)
-        unc_path = decoded.replace("/", "\\")  # UNC path on Windows share
+        unc_path = os.path.normpath(os.path.join(BASE_DIR, decoded))  # Normalize path
+
+        if not unc_path.startswith(str(BASE_DIR)):
+            logger.warning("Attempted access to unauthorized path", extra={"path": unc_path})
+            raise HTTPException(status_code=403, detail="Access to this file is forbidden")
 
         if not os.path.exists(unc_path):
             logger.info("File not found", extra={"path": unc_path})


### PR DESCRIPTION
Potential fix for [https://github.com/BakedChicken77/DRSearch/security/code-scanning/1](https://github.com/BakedChicken77/DRSearch/security/code-scanning/1)

To fix the issue, we need to ensure that the constructed file path (`unc_path`) is restricted to a safe root directory. This can be achieved by:
1. Defining a safe base directory (e.g., `BASE_DIR` or a specific subdirectory for file storage).
2. Normalizing the constructed path using `os.path.normpath` to remove any `..` segments.
3. Verifying that the normalized path starts with the safe base directory to prevent directory traversal.

The fix will involve:
- Adding a base directory for file storage.
- Normalizing the `unc_path` and validating it against the base directory.
- Raising an exception if the path is outside the allowed directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
