### PR TITLE
Fix hardcoded dev token

### DIFF
--- a/drsearch_frontend/.example.env
+++ b/drsearch_frontend/.example.env
@@ -30,3 +30,6 @@ NEXT_PUBLIC_AZURE_AD_REDIRECT_URI=http://localhost:3000/api/auth/callback/azure-
 
 # API Scope to request access from backend (Application ID URL with '/access_as_user' path)
 NEXT_PUBLIC_AZURE_AD_API_SCOPE=api://secret/access_as_user
+
+# Development access token for local testing
+NEXT_PUBLIC_DEV_ACCESS_TOKEN=dev-access-token

--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -92,7 +92,10 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
     if (!session) return <p>You are not authenticated. Please sign in.</p>; // istanbul ignore next
     accessToken = session.accessToken as string;
   } else {
-    accessToken = "dev-access-token";
+    accessToken =
+      process.env.NODE_ENV === "development"
+        ? process.env.NEXT_PUBLIC_DEV_ACCESS_TOKEN ?? ""
+        : "";
   }
 
   // send a chat message


### PR DESCRIPTION
## Summary
- replace hard-coded dev access token in `ChatWindow` with env var
- document `NEXT_PUBLIC_DEV_ACCESS_TOKEN` in sample env

## Testing
- `yarn lint`
- `yarn test --coverage`
- `poetry run pytest --cov=app --cov-report=term-missing -q`
