### PR TITLE
Improve ChatEngine index fallback

### DIFF
--- a/drsearch_backend/app/chain/engine.py
+++ b/drsearch_backend/app/chain/engine.py
@@ -22,7 +22,6 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_openai import AzureChatOpenAI
 
 from app import System_Prompts
-from app.chain.exceptions import ConfigurationError
 from app.chain.formatter import DocumentFormatter
 from app.chain.history import HistorySerializer
 from app.chain.mapping import PartNumberMapping
@@ -40,7 +39,17 @@ class ChatEngine:
         self._index_name = index_name
         self._cfg = INDEX_CONFIG.get(index_name)
         if self._cfg is None:
-            raise ConfigurationError(f"Unknown index '{index_name}'")
+            logger.warning(
+                "Unknown index '%s' – running in chatbot-only mode", index_name
+            )
+            self._cfg = {
+                "response_template": System_Prompts.RESPONSE_TEMPLATE_CHATBOT,
+                "PN_TO_FILE_MAPPING": None,
+                "DECOMPOSER": System_Prompts.QUESTION_DECOMPOSER2,
+            }
+            self._unknown_index = True
+        else:
+            self._unknown_index = False
         self._mapping = PartNumberMapping(self._cfg["PN_TO_FILE_MAPPING"])
         self._llm = self._init_llm()
         self._answer_chain = self._build_answer_chain()
@@ -91,7 +100,7 @@ class ChatEngine:
         format_docs_fn: Callable[[Sequence[Document]], str] | None = None
 
         enable_retrieval = False
-        if RAG_ON:
+        if RAG_ON and not getattr(self, "_unknown_index", False):
             try:
                 retriever = RetrieverFactory.build(self._index_name)
                 raw_retriever = RetrieverFactory.build(self._index_name)
@@ -104,6 +113,12 @@ class ChatEngine:
                 )
                 response_template = System_Prompts.RESPONSE_TEMPLATE_CHATBOT
                 enable_retrieval = False
+        elif RAG_ON and getattr(self, "_unknown_index", False):
+            logger.warning(
+                "Index '%s' not configured – retrieval disabled", self._index_name
+            )
+            response_template = System_Prompts.RESPONSE_TEMPLATE_CHATBOT
+            enable_retrieval = False
         else:
             logger.info("Running in chatbot-only mode – retrieval disabled")
 

--- a/drsearch_backend/tests/test_chat_engine.py
+++ b/drsearch_backend/tests/test_chat_engine.py
@@ -7,7 +7,6 @@ from langchain.prompts import ChatPromptTemplate
 from app import System_Prompts
 
 from app.chain.engine import ChatEngine
-from app.chain.exceptions import ConfigurationError
 from tests.conftest import _DummyRetriever  # type: ignore
 
 
@@ -19,9 +18,25 @@ class DummyLLM:
 dummy_llm = RunnableLambda(DummyLLM())
 
 
-def test_chat_engine_unknown_index():
-    with pytest.raises(ConfigurationError):
-        ChatEngine("does-not-exist")
+def test_chat_engine_unknown_index(monkeypatch):
+    """Unknown index should default to chatbot-only mode."""
+
+    captured: dict[str, str] = {}
+    orig_from_messages = ChatPromptTemplate.from_messages
+
+    def capture(msgs):
+        captured["system"] = msgs[0][1]
+        return orig_from_messages(msgs)
+
+    monkeypatch.setattr(
+        "app.chain.engine.ChatPromptTemplate.from_messages",
+        capture,
+    )
+
+    eng = ChatEngine("does-not-exist")
+    out = eng.answer_chain.invoke({"question": "hi", "chat_history": []})
+    assert out == "LLM-OK"
+    assert captured["system"] == System_Prompts.RESPONSE_TEMPLATE_CHATBOT
 
 
 def test_chat_engine_answer_chain_simple_RAG_OFF(monkeypatch):


### PR DESCRIPTION
## Summary
- allow ChatEngine to continue when an unknown index is requested
- capture system prompt in unknown index test

## Testing
- `cd drsearch_backend && poetry run pytest --cov=app --cov-report=term-missing -q`