### PR TITLE
Add sidebar setting for document retrieval count

### DIFF
--- a/drsearch_backend/app/chain/api.py
+++ b/drsearch_backend/app/chain/api.py
@@ -2,27 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Tuple
 from langchain.schema.runnable import Runnable, RunnableLambda
 
 from app.chain.engine import ChatEngine
-from app.core.chain_config import _DEFAULT_INDEX
+from app.core.chain_config import _DEFAULT_INDEX, _NUMBER_OF_DOCS_RETRIEVED
 
-_engine_cache: Dict[str, ChatEngine] = {}
-
-
-def _engine_for(index_name: str) -> ChatEngine:
-    """Retrieve or create a cached ChatEngine for the given index."""
-    if index_name not in _engine_cache:
-        _engine_cache[index_name] = ChatEngine(index_name)
-    return _engine_cache[index_name]
+_engine_cache: Dict[Tuple[str, int], ChatEngine] = {}
 
 
-def get_answer_chain(index_name: str | None = None) -> Runnable:
+def _engine_for(index_name: str, num_docs: int) -> ChatEngine:
+    """Retrieve or create a cached ChatEngine for the given index and k."""
+    key = (index_name, num_docs)
+    if key not in _engine_cache:
+        # Update global setting before engine creation
+        from app.core import chain_config
+
+        chain_config._NUMBER_OF_DOCS_RETRIEVED = num_docs
+        _engine_cache[key] = ChatEngine(index_name)
+    return _engine_cache[key]
+
+
+def get_answer_chain(index_name: str | None = None, num_docs: int = _NUMBER_OF_DOCS_RETRIEVED) -> Runnable:
     """Return the langchain Runnable for the specified index (cached)."""
-    return _engine_for(index_name or _DEFAULT_INDEX).answer_chain
+    return _engine_for(index_name or _DEFAULT_INDEX, num_docs).answer_chain
 
 
 answer_chain: Runnable = RunnableLambda(
-    lambda inputs: get_answer_chain(inputs.get("index_name", _DEFAULT_INDEX))
+    lambda inputs: get_answer_chain(
+        inputs.get("index_name", _DEFAULT_INDEX),
+        inputs.get("num_docs_retrieved", _NUMBER_OF_DOCS_RETRIEVED),
+    )
 )

--- a/drsearch_backend/app/models/chat.py
+++ b/drsearch_backend/app/models/chat.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from app.core.chain_config import _NUMBER_OF_DOCS_RETRIEVED
+
 
 class ChatRequest(BaseModel):
     """Input model for chat requests."""
@@ -18,5 +20,12 @@ class ChatRequest(BaseModel):
     index_name: Optional[str] = Field(
         default=None,
         description="Optional override for the Weaviate index name",
+    )
+
+    num_docs_retrieved: int = Field(
+        default=_NUMBER_OF_DOCS_RETRIEVED,
+        ge=1,
+        le=5,
+        description="How many documents to retrieve for each query",
     )
 

--- a/drsearch_backend/tests/test_chain_api.py
+++ b/drsearch_backend/tests/test_chain_api.py
@@ -16,13 +16,13 @@ def test__engine_for_creates_and_caches(monkeypatch):
     monkeypatch.setattr("app.chain.api.ChatEngine", DummyChatEngine)
 
     # First call – should instantiate
-    engine = api._engine_for("TEST_INDEX")
+    engine = api._engine_for("TEST_INDEX", 3)
     assert isinstance(engine, DummyChatEngine)
     assert engine.index_name == "TEST_INDEX"
     assert engine.answer_chain is dummy_chain
 
     # Second call – should hit cache
-    cached = api._engine_for("TEST_INDEX")
+    cached = api._engine_for("TEST_INDEX", 3)
     assert cached is engine
 
 
@@ -37,11 +37,11 @@ def test_get_answer_chain(monkeypatch):
     api._engine_cache.clear()
 
     # Should use default index if None passed
-    result = api.get_answer_chain(None)
+    result = api.get_answer_chain(None, 3)
     assert result is dummy_chain
 
     # Should use custom index
-    result2 = api.get_answer_chain("ALT_INDEX")
+    result2 = api.get_answer_chain("ALT_INDEX", 3)
     assert result2 is dummy_chain
 
 
@@ -56,5 +56,5 @@ def test_answer_chain_lambda(monkeypatch):
     api._engine_cache.clear()
 
     # Call the global RunnableLambda (simulate LangChain request input)
-    result = api.answer_chain.invoke({"index_name": "JACSKE_Program"})
+    result = api.answer_chain.invoke({"index_name": "JACSKE_Program", "num_docs_retrieved": 3})
     assert result is dummy_chain

--- a/drsearch_backend/tests/test_extra_coverage.py
+++ b/drsearch_backend/tests/test_extra_coverage.py
@@ -76,12 +76,16 @@ def test_mapping_no_file(tmp_path):
 def test_models_chat_request():
     """Ensure the Pydantic model validates and serialises as expected."""
     req = ChatRequest(
-        question="q", chat_history=[{"human": "h", "ai": "a"}], index_name="idx"
+        question="q",
+        chat_history=[{"human": "h", "ai": "a"}],
+        index_name="idx",
+        num_docs_retrieved=4,
     )
     data = req.dict()
     assert data["question"] == "q"
     assert data["chat_history"][0]["human"] == "h"
     assert data["index_name"] == "idx"
+    assert data["num_docs_retrieved"] == 4
 
 
 def test_settings_split_origins():

--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -1,6 +1,5 @@
 // app\components\ChatWindow.tsx
 
-
 "use client";
 
 import React, { useRef, useState, useEffect } from "react";
@@ -27,10 +26,14 @@ import {
 } from "@chakra-ui/react";
 import { ArrowUpIcon } from "@chakra-ui/icons";
 import { Source } from "./SourceBubble";
+import { SettingsDrawer } from "./SettingsDrawer";
 import { apiBaseUrl } from "../utils/constants";
 import { fetchIndexOptions, IndexOption } from "../utils/fetchIndexOptions";
 
-export function ChatWindow(props: { placeholder?: string; titleText?: string }) {
+export function ChatWindow(props: {
+  placeholder?: string;
+  titleText?: string;
+}) {
   // conversation/session identifiers
   const [conversationId, setConversationId] = useState<string>(uuidv4());
   const messageContainerRef = useRef<HTMLDivElement | null>(null);
@@ -39,14 +42,17 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [chatHistory, setChatHistory] = useState<{ human: string; ai: string }[]>(
-    []
-  );
+  const [chatHistory, setChatHistory] = useState<
+    { human: string; ai: string }[]
+  >([]);
 
   const { placeholder, titleText = "DRS ASSISTANT" } = props;
 
   // index selection
   const [selectedIndexName, setSelectedIndexName] = useState("");
+
+  // number of docs
+  const [numDocs, setNumDocs] = useState(3);
 
   // fetched options
   const [indexOptions, setIndexOptions] = useState<IndexOption[] | null>(null);
@@ -69,7 +75,7 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
     (async () => {
       try {
         const opts = await fetchIndexOptions(
-          AUTH_ENABLED             ? accessToken             : undefined
+          AUTH_ENABLED ? accessToken : undefined,
         );
         setIndexOptions(opts);
       } catch (e: any) {
@@ -94,7 +100,7 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
   } else {
     accessToken =
       process.env.NODE_ENV === "development"
-        ? process.env.NEXT_PUBLIC_DEV_ACCESS_TOKEN ?? ""
+        ? (process.env.NEXT_PUBLIC_DEV_ACCESS_TOKEN ?? "")
         : "";
   }
 
@@ -158,17 +164,18 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
             question: messageValue,
             chat_history: chatHistory,
             index_name: selectedIndexName,
+            num_docs_retrieved: numDocs,
           },
           config: { metadata: { conversation_id: conversationId } },
           include_names: ["FindDocs"],
         }),
         openWhenHidden: true,
-          onerror(err) {
-            /* istanbul ignore next */
-            console.error("Error in EventSource:", err);
-            /* istanbul ignore next */
-            throw err;
-          },
+        onerror(err) {
+          /* istanbul ignore next */
+          console.error("Error in EventSource:", err);
+          /* istanbul ignore next */
+          throw err;
+        },
         onmessage(msg) {
           if (msg.event === "end") {
             setChatHistory((h) => [
@@ -185,23 +192,17 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
             // ═ Apply patches to our persistent object ═
             streamedResponse = applyPatch(
               streamedResponse,
-              chunk.ops
+              chunk.ops,
             ).newDocument;
 
             const doc = streamedResponse;
 
             // extract sources if present
-            if (
-              Array.isArray(
-                doc.logs?.FindDocs?.final_output?.output
-              )
-            ) {
-              sources = doc.logs.FindDocs.final_output.output.map(
-                (d: any) => ({
-                  url: d.metadata.file_path,
-                  title: d.metadata.filename,
-                })
-              );
+            if (Array.isArray(doc.logs?.FindDocs?.final_output?.output)) {
+              sources = doc.logs.FindDocs.final_output.output.map((d: any) => ({
+                url: d.metadata.file_path,
+                title: d.metadata.filename,
+              }));
             }
 
             // track run ID
@@ -236,18 +237,18 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
           }
         },
       });
-      } catch (e) {
-        /* istanbul ignore next */
-        console.error("Send message error:", e);
-        /* istanbul ignore next */
-        setMessages((prev) => prev.slice(0, -1));
-        /* istanbul ignore next */
-        setIsLoading(false);
-        /* istanbul ignore next */
-        setInput(messageValue);
-        /* istanbul ignore next */
-        throw e;
-      }
+    } catch (e) {
+      /* istanbul ignore next */
+      console.error("Send message error:", e);
+      /* istanbul ignore next */
+      setMessages((prev) => prev.slice(0, -1));
+      /* istanbul ignore next */
+      setIsLoading(false);
+      /* istanbul ignore next */
+      setInput(messageValue);
+      /* istanbul ignore next */
+      throw e;
+    }
   };
 
   // initial question helper
@@ -255,6 +256,7 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
 
   return (
     <div className="flex flex-col items-center p-8 rounded grow max-h-full">
+      <SettingsDrawer numDocs={numDocs} setNumDocs={setNumDocs} />
       {messages.length > 0 ? (
         <Flex direction="column" alignItems="center" pb="20px">
           <Heading fontSize="8xl" fontWeight="medium" mb={1} color="black">
@@ -271,9 +273,7 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
             placeholder="Select Document Index"
             mb="20px"
             width="auto"
-            isDisabled={
-              loadingOptions || (indexOptions?.length ?? 0) === 0
-            }
+            isDisabled={loadingOptions || (indexOptions?.length ?? 0) === 0}
           >
             {indexOptions?.map((opt) => (
               <option key={opt.name} value={opt.name}>
@@ -317,14 +317,14 @@ export function ChatWindow(props: { placeholder?: string; titleText?: string }) 
           value={input}
           maxRows={20}
           mr="56px"
-            placeholder={placeholder}
-            textColor="black"
-            borderColor="rgb(58, 58, 61)"
-            isDisabled={!selectedIndexName}
-            _disabled={{
-              backgroundColor: "gray.200",
-              cursor: "not-allowed",
-            }} /* istanbul ignore next */
+          placeholder={placeholder}
+          textColor="black"
+          borderColor="rgb(58, 58, 61)"
+          isDisabled={!selectedIndexName}
+          _disabled={{
+            backgroundColor: "gray.200",
+            cursor: "not-allowed",
+          }} /* istanbul ignore next */
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {

--- a/drsearch_frontend/app/components/SettingsDrawer.tsx
+++ b/drsearch_frontend/app/components/SettingsDrawer.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React from "react";
+import {
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHeader,
+  DrawerBody,
+  DrawerCloseButton,
+  IconButton,
+  useDisclosure,
+  FormControl,
+  FormLabel,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
+} from "@chakra-ui/react";
+import { SettingsIcon } from "@chakra-ui/icons";
+
+export function SettingsDrawer({
+  numDocs,
+  setNumDocs,
+}: {
+  numDocs: number;
+  setNumDocs: (v: number) => void;
+}) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  return (
+    <>
+      <IconButton
+        aria-label="Open settings"
+        icon={<SettingsIcon />}
+        position="absolute"
+        top={2}
+        left={2}
+        onClick={onOpen}
+      />
+      <Drawer placement="left" onClose={onClose} isOpen={isOpen} size="xs">
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>Settings</DrawerHeader>
+          <DrawerBody>
+            <FormControl>
+              <FormLabel>Documents to retrieve</FormLabel>
+              <NumberInput
+                min={1}
+                max={5}
+                value={numDocs}
+                onChange={(_s, v) => setNumDocs(v)}
+              >
+                <NumberInputField />
+                <NumberInputStepper>
+                  <NumberIncrementStepper />
+                  <NumberDecrementStepper />
+                </NumberInputStepper>
+              </NumberInput>
+            </FormControl>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- allow customizing `_NUMBER_OF_DOCS_RETRIEVED` via frontend
- add minimizable settings drawer in `ChatWindow`
- send chosen value with chat requests
- adjust backend to rebuild chat engine per document-count
- extend tests for new request field

## Testing
- `yarn lint`
- `yarn format`
- `yarn test --coverage`
- `poetry run pytest --cov=app --cov-report=term-missing -q`