### PR TITLE
Add pluggable vector DB layer

### DIFF
--- a/drsearch_backend/.example.env
+++ b/drsearch_backend/.example.env
@@ -41,3 +41,5 @@ AZURE_AD_CLIENT_SECRET=secret
 WEAVIATE_URL=http://weaviate:8080
 WEAVIATE_API_KEY=key
 RECORD_MANAGER_DB_URL=postgresql://username:yourpassword@postgres_drsearch:5432/recordmanager_db
+VECTOR_BACKEND=weaviate
+PGVECTOR_CONNECTION=postgresql://username:yourpassword@postgres_drsearch:5432/vector_db

--- a/drsearch_backend/app/chain/retriever.py
+++ b/drsearch_backend/app/chain/retriever.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-import weaviate
 from langchain.schema.retriever import BaseRetriever
-from langchain_community.vectorstores import Weaviate as WeaviateStore
 
 from app.chain.exceptions import ConfigurationError
-from app.chain.embeddings import EmbeddingFactory
-from app.core.chain_config import _WEAVIATE_URL, _WEAVIATE_API_KEY, _NUMBER_OF_DOCS_RETRIEVED
+from app.core.chain_config import (
+    _VECTOR_BACKEND,
+    _NUMBER_OF_DOCS_RETRIEVED,
+)
 from app.index_config import INDEX_CONFIG
+from app.vector_store import get_vector_store
 
 
 class RetrieverFactory:
-    """Factory for langchain retrievers backed by Weaviate."""
+    """Factory for langchain retrievers backed by the configured vector store."""
 
     @staticmethod
     def build(index_name: str) -> BaseRetriever:
@@ -25,24 +26,21 @@ class RetrieverFactory:
         if cfg is None:
             raise ConfigurationError(f"Index '{index_name}' not defined in INDEX_CONFIG")
 
-        client = weaviate.Client(
-            url=_WEAVIATE_URL,
-            auth_client_secret=weaviate.AuthApiKey(api_key=_WEAVIATE_API_KEY),
-        )
-        store = WeaviateStore(
-            client=client,
-            index_name=index_name,
+        store = get_vector_store(
+            index_name,
             text_key=cfg["index_key"],
-            embedding=EmbeddingFactory.get(),
-            by_text=False,
             attributes=cfg["attributes"],
         )
 
-        filter_rag_only = {
-            "operator": "Equal",
-            "path": ["use4RAG"],
-            "valueBoolean": True,
-        }
-        return store.as_retriever(
-            search_kwargs={"k": _NUMBER_OF_DOCS_RETRIEVED, "where_filter": filter_rag_only}
-        )
+        filter_rag_only = {"use4RAG": True}
+        search_kwargs = {"k": _NUMBER_OF_DOCS_RETRIEVED}
+        if _VECTOR_BACKEND == "weaviate":
+            search_kwargs["where_filter"] = {
+                "operator": "Equal",
+                "path": ["use4RAG"],
+                "valueBoolean": True,
+            }
+        else:
+            search_kwargs["filter"] = filter_rag_only
+
+        return store.as_retriever(search_kwargs=search_kwargs)

--- a/drsearch_backend/app/core/chain_config.py
+++ b/drsearch_backend/app/core/chain_config.py
@@ -37,6 +37,15 @@ else:  # Database details optional when RAG disabled
     _WEAVIATE_URL = os.getenv("WEAVIATE_URL", "")
     _WEAVIATE_API_KEY = os.getenv("WEAVIATE_API_KEY", "")
 
+#: Vector DB backend selection
+_VECTOR_BACKEND: str = os.getenv("VECTOR_BACKEND", "weaviate").lower()
+
+#: Connection string for pgvector when selected
+_PGVECTOR_CONNECTION: str = os.getenv(
+    "PGVECTOR_CONNECTION",
+    "postgresql://username:yourpassword@postgres_drsearch:5432/vector_db",
+)
+
 #: Whether Auth is enabled (True/False)
 _AUTH_ENABLED: bool = os.getenv("AUTH_ENABLED", "True") == "True"
 

--- a/drsearch_backend/app/vector_store/__init__.py
+++ b/drsearch_backend/app/vector_store/__init__.py
@@ -1,0 +1,13 @@
+"""Vector store abstraction and backend implementations."""
+
+from .base import VectorStore
+from .factory import get_vector_store
+from .weaviate_store import WeaviateVectorStore
+from .pgvector_store import PgVectorStore
+
+__all__ = [
+    "VectorStore",
+    "get_vector_store",
+    "WeaviateVectorStore",
+    "PgVectorStore",
+]

--- a/drsearch_backend/app/vector_store/base.py
+++ b/drsearch_backend/app/vector_store/base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, List
+
+from langchain.schema import Document
+from langchain.schema.retriever import BaseRetriever
+
+
+class VectorStore(ABC):
+    """Abstract interface for vector database implementations."""
+
+    @abstractmethod
+    def store_vector(self, docs: Iterable[Document]) -> None:
+        """Persist documents to the vector database."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def query_similar(self, query: str, k: int, where: dict | None = None) -> List[Document]:
+        """Return documents similar to *query*."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_vector(self, doc_id: str) -> None:
+        """Delete document with *doc_id* from the vector database."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_vector(self, doc_id: str, doc: Document) -> None:
+        """Replace an existing document by *doc_id* with *doc*."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def as_retriever(self, **kwargs) -> BaseRetriever:
+        """Return a langchain retriever for this store."""
+        raise NotImplementedError

--- a/drsearch_backend/app/vector_store/factory.py
+++ b/drsearch_backend/app/vector_store/factory.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+
+from .weaviate_store import WeaviateVectorStore
+from .pgvector_store import PgVectorStore
+
+
+def get_vector_store(index_name: str, *, text_key: str, attributes: list[str]):
+    """Return a VectorStore instance according to ``VECTOR_BACKEND`` env-var."""
+    backend = os.getenv("VECTOR_BACKEND", "weaviate").lower()
+    if backend == "weaviate":
+        return WeaviateVectorStore(index_name, text_key, attributes)
+    if backend == "pgvector":
+        return PgVectorStore(index_name)
+    raise ValueError(f"Unsupported VECTOR_BACKEND '{backend}'")

--- a/drsearch_backend/app/vector_store/pgvector_store.py
+++ b/drsearch_backend/app/vector_store/pgvector_store.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from langchain_community.vectorstores.pgvector import PGVector
+from langchain.schema import Document
+from langchain.schema.retriever import BaseRetriever
+
+from app.chain.embeddings import EmbeddingFactory
+from app.core.chain_config import _PGVECTOR_CONNECTION
+from .base import VectorStore
+
+
+class PgVectorStore(VectorStore):
+    """Vector store implementation backed by PostgreSQL with pgvector."""
+
+    def __init__(self, index_name: str):
+        self.index_name = index_name
+        self._store = PGVector(
+            connection_string=_PGVECTOR_CONNECTION,
+            embedding_function=EmbeddingFactory.get(),
+            collection_name=index_name,
+        )
+
+    def store_vector(self, docs: Iterable[Document]) -> None:
+        self._store.add_documents(list(docs))
+
+    def query_similar(self, query: str, k: int, where: dict | None = None) -> List[Document]:
+        return self._store.similarity_search(query, k=k, filter=where)
+
+    def delete_vector(self, doc_id: str) -> None:
+        self._store.delete(doc_id)
+
+    def update_vector(self, doc_id: str, doc: Document) -> None:
+        self.delete_vector(doc_id)
+        self.store_vector([doc])
+
+    def as_retriever(self, **kwargs) -> BaseRetriever:
+        return self._store.as_retriever(**kwargs)

--- a/drsearch_backend/app/vector_store/weaviate_store.py
+++ b/drsearch_backend/app/vector_store/weaviate_store.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import weaviate
+from langchain_community.vectorstores import Weaviate as LCWeaviate
+from langchain.schema import Document
+from langchain.schema.retriever import BaseRetriever
+
+from app.chain.embeddings import EmbeddingFactory
+from app.core.chain_config import _WEAVIATE_API_KEY, _WEAVIATE_URL
+from .base import VectorStore
+
+
+class WeaviateVectorStore(VectorStore):
+    """Vector store implementation backed by Weaviate."""
+
+    def __init__(self, index_name: str, text_key: str, attributes: list[str]):
+        self.index_name = index_name
+        self.client = weaviate.Client(
+            url=_WEAVIATE_URL,
+            auth_client_secret=weaviate.AuthApiKey(api_key=_WEAVIATE_API_KEY),
+        )
+        self._store = LCWeaviate(
+            client=self.client,
+            index_name=index_name,
+            text_key=text_key,
+            embedding=EmbeddingFactory.get(),
+            by_text=False,
+            attributes=attributes,
+        )
+
+    def store_vector(self, docs: Iterable[Document]) -> None:
+        self._store.add_documents(list(docs))
+
+    def query_similar(self, query: str, k: int, where: dict | None = None) -> List[Document]:
+        return self._store.similarity_search(query, k=k, where=where)
+
+    def delete_vector(self, doc_id: str) -> None:
+        self.client.batch.delete_objects(
+            class_name=self.index_name,
+            where={"path": ["id"], "operator": "Equal", "valueString": doc_id},
+        )
+
+    def update_vector(self, doc_id: str, doc: Document) -> None:
+        self.delete_vector(doc_id)
+        self.store_vector([doc])
+
+    def as_retriever(self, **kwargs) -> BaseRetriever:
+        return self._store.as_retriever(**kwargs)

--- a/drsearch_backend/tests/test_vector_store_factory.py
+++ b/drsearch_backend/tests/test_vector_store_factory.py
@@ -1,0 +1,20 @@
+from app.vector_store import get_vector_store, WeaviateVectorStore, PgVectorStore
+
+
+def test_get_vector_store_default(monkeypatch):
+    monkeypatch.delenv("VECTOR_BACKEND", raising=False)
+    store = get_vector_store("idx", text_key="text", attributes=[])
+    assert isinstance(store, WeaviateVectorStore)
+
+
+def test_get_vector_store_pgvector(monkeypatch):
+    monkeypatch.setenv("VECTOR_BACKEND", "pgvector")
+    monkeypatch.setenv("PGVECTOR_CONNECTION", "postgresql://user:pass@host/db")
+
+    class Dummy(PgVectorStore):
+        def __init__(self, index_name: str) -> None:  # pragma: no cover
+            self.index_name = index_name
+
+    monkeypatch.setattr("app.vector_store.factory.PgVectorStore", Dummy)
+    store = get_vector_store("idx", text_key="text", attributes=[])
+    assert isinstance(store, Dummy)


### PR DESCRIPTION
## Summary
- introduce vector_store module with base class and two implementations
- support pgvector via PgVectorStore
- allow backend selection using VECTOR_BACKEND and PGVECTOR_CONNECTION
- update RetrieverFactory to use the new abstraction
- add tests for selecting the vector store backend

## Testing
- `cd drsearch_backend && poetry run pytest --cov=app --cov-report=term-missing -q`
- `cd drsearch_frontend && yarn lint`
- `yarn test --coverage`
- `yarn format`
