### PR TITLE
Add pluggable vector store backend

### DIFF
--- a/drsearch_backend/.example.env
+++ b/drsearch_backend/.example.env
@@ -41,3 +41,8 @@ AZURE_AD_CLIENT_SECRET=secret
 WEAVIATE_URL=http://weaviate:8080
 WEAVIATE_API_KEY=key
 RECORD_MANAGER_DB_URL=postgresql://username:yourpassword@postgres_drsearch:5432/recordmanager_db
+
+# Vector database backend: "weaviate" or "pgvector"
+VECTOR_BACKEND=weaviate
+# PostgreSQL connection string used when VECTOR_BACKEND=pgvector
+PGVECTOR_URL=postgresql://username:password@postgres_drsearch:5432/pgvector_db

--- a/drsearch_backend/app/chain/retriever.py
+++ b/drsearch_backend/app/chain/retriever.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import weaviate
 from langchain.schema.retriever import BaseRetriever
-from langchain_community.vectorstores import Weaviate as WeaviateStore
 
 from app.chain.exceptions import ConfigurationError
-from app.chain.embeddings import EmbeddingFactory
 from app.core import chain_config
 from app.index_config import INDEX_CONFIG
+from app.vectorstores.factory import VectorStoreFactory
 
 
 class RetrieverFactory:
@@ -23,26 +21,21 @@ class RetrieverFactory:
         """
         cfg = INDEX_CONFIG.get(index_name)
         if cfg is None:
-            raise ConfigurationError(f"Index '{index_name}' not defined in INDEX_CONFIG")
+            raise ConfigurationError(
+                f"Index '{index_name}' not defined in INDEX_CONFIG"
+            )
 
-        client = weaviate.Client(
-            url=chain_config._WEAVIATE_URL,
-            auth_client_secret=weaviate.AuthApiKey(api_key=chain_config._WEAVIATE_API_KEY),
-        )
-        store = WeaviateStore(
-            client=client,
-            index_name=index_name,
-            text_key=cfg["index_key"],
-            embedding=EmbeddingFactory.get(),
-            by_text=False,
-            attributes=cfg["attributes"],
-        )
+        store = VectorStoreFactory.create(index_name)
 
         filter_rag_only = {
             "operator": "Equal",
             "path": ["use4RAG"],
             "valueBoolean": True,
         }
+
         return store.as_retriever(
-            search_kwargs={"k": chain_config._NUMBER_OF_DOCS_RETRIEVED, "where_filter": filter_rag_only}
+            search_kwargs={
+                "k": chain_config._NUMBER_OF_DOCS_RETRIEVED,
+                "where_filter": filter_rag_only,
+            }
         )

--- a/drsearch_backend/app/core/chain_config.py
+++ b/drsearch_backend/app/core/chain_config.py
@@ -23,6 +23,12 @@ load_dotenv()
 #: Toggle RAG vs. plain-chatbot mode
 RAG_ON: bool = os.getenv("RAG_ON", "True").lower() == "true"
 
+#: Vector database backend to use ("weaviate" or "pgvector")
+_VECTOR_BACKEND: str = os.getenv("VECTOR_BACKEND", "weaviate").lower()
+
+#: Connection string for pgvector when using the PostgreSQL backend
+_PGVECTOR_URL: str = os.getenv("PGVECTOR_URL", "")
+
 #: How many documents to pull per query when RAG_ON
 _NUMBER_OF_DOCS_RETRIEVED: int = 3
 

--- a/drsearch_backend/app/vectorstores/__init__.py
+++ b/drsearch_backend/app/vectorstores/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from langchain.schema.retriever import BaseRetriever
+
+
+class VectorStore(ABC):
+    """Abstract interface for vector store backends."""
+
+    @abstractmethod
+    def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
+        """Return a LangChain retriever for this store."""
+        raise NotImplementedError
+
+
+__all__ = ["VectorStore"]

--- a/drsearch_backend/app/vectorstores/factory.py
+++ b/drsearch_backend/app/vectorstores/factory.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from . import VectorStore
+from .weaviate_store import WeaviateVectorStore
+from .pgvector_store import PgVectorStore
+from app.core import chain_config
+
+
+class VectorStoreFactory:
+    """Instantiate vector store backend based on configuration."""
+
+    @staticmethod
+    def create(index_name: str) -> VectorStore:
+        if chain_config._VECTOR_BACKEND == "pgvector":
+            return PgVectorStore(index_name)
+        return WeaviateVectorStore(index_name)

--- a/drsearch_backend/app/vectorstores/pgvector_store.py
+++ b/drsearch_backend/app/vectorstores/pgvector_store.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_community.vectorstores.pgvector import PGVector
+from langchain.schema.retriever import BaseRetriever
+
+from app.chain.embeddings import EmbeddingFactory
+from app.core import chain_config
+
+from . import VectorStore
+
+
+class PgVectorStore(VectorStore):
+    """Vector store backed by PostgreSQL with pgvector."""
+
+    def __init__(self, index_name: str) -> None:
+        self._store = PGVector(
+            connection_string=chain_config._PGVECTOR_URL,
+            embedding_function=EmbeddingFactory.get(),
+            collection_name=index_name,
+        )
+
+    def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
+        return self._store.as_retriever(search_kwargs=search_kwargs)

--- a/drsearch_backend/app/vectorstores/weaviate_store.py
+++ b/drsearch_backend/app/vectorstores/weaviate_store.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+import weaviate
+from langchain_community.vectorstores import Weaviate as LangchainWeaviate
+from langchain.schema.retriever import BaseRetriever
+
+from app.chain.embeddings import EmbeddingFactory
+from app.core import chain_config
+from app.index_config import INDEX_CONFIG
+
+from . import VectorStore
+
+
+class WeaviateVectorStore(VectorStore):
+    """Vector store backed by Weaviate."""
+
+    def __init__(self, index_name: str) -> None:
+        cfg = INDEX_CONFIG[index_name]
+        client = weaviate.Client(
+            url=chain_config._WEAVIATE_URL,
+            auth_client_secret=weaviate.AuthApiKey(api_key=chain_config._WEAVIATE_API_KEY),
+        )
+        self._store = LangchainWeaviate(
+            client=client,
+            index_name=index_name,
+            text_key=cfg["index_key"],
+            embedding=EmbeddingFactory.get(),
+            by_text=False,
+            attributes=cfg["attributes"],
+        )
+
+    def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
+        return self._store.as_retriever(search_kwargs=search_kwargs)

--- a/drsearch_backend/tests/conftest.py
+++ b/drsearch_backend/tests/conftest.py
@@ -19,6 +19,8 @@ _DUMMY_ENV: Dict[str, str] = {
     "AZURE_OPENAI_DEPLOYMENT_NAME": "dummy-model",
     "AZURE_OPENAI_ENDPOINT": "https://dummy-endpoint.openai.azure.com/",
     "AZURE_OPENAI_API_KEY": "dummy-key",
+    "VECTOR_BACKEND": "weaviate",
+    "PGVECTOR_URL": "postgresql://user:pass@localhost/db",
     # RAG is enabled by default during tests
     "RAG_ON": "True",
     # Auth (turned OFF for most tests – can be re-enabled where needed)
@@ -117,6 +119,14 @@ class _FakeWeavStore:
         return _DummyRetriever()
 
 
+class _FakePgVector:
+    def __init__(self, *a, **k):
+        ...
+
+    def as_retriever(self, *a, **k):
+        return _DummyRetriever()
+
+
 @pytest.fixture(autouse=True)
 def _patch_external(monkeypatch):
     # LLM & embeddings
@@ -129,6 +139,16 @@ def _patch_external(monkeypatch):
     monkeypatch.setattr("weaviate.Client", FakeClient, raising=False)
     monkeypatch.setattr(
         "langchain_community.vectorstores.Weaviate", _FakeWeavStore, raising=False
+    )
+    monkeypatch.setattr(
+        "langchain_community.vectorstores.pgvector.PGVector",
+        _FakePgVector,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.vectorstores.pgvector_store.PGVector",
+        _FakePgVector,
+        raising=False,
     )
     yield
 

--- a/drsearch_backend/tests/test_retriever_factory.py
+++ b/drsearch_backend/tests/test_retriever_factory.py
@@ -17,3 +17,13 @@ def test_retriever_factory_success(monkeypatch):
 def test_retriever_factory_bad_index(monkeypatch):
     with pytest.raises(ConfigurationError):
         RetrieverFactory.build("missing")
+
+
+def test_retriever_factory_pgvector(monkeypatch):
+    monkeypatch.setattr("app.core.chain_config._VECTOR_BACKEND", "pgvector")
+    monkeypatch.setattr(
+        "app.core.chain_config._PGVECTOR_URL",
+        "postgresql://user:pass@localhost/db",
+    )
+    r = RetrieverFactory.build("JACSKE_Program")
+    assert isinstance(r, BaseRetriever)


### PR DESCRIPTION
## Summary
- enable selection of vector DB backend via `VECTOR_BACKEND`
- add pgvector support using a new VectorStore abstraction
- refactor RetrieverFactory to use the backend factory
- extend tests to cover pgvector backend

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`