### PR TITLE
Add new chat button

### DIFF
--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -24,7 +24,7 @@ import {
   Spinner,
   Select,
 } from "@chakra-ui/react";
-import { ArrowUpIcon } from "@chakra-ui/icons";
+import { ArrowUpIcon, AddIcon } from "@chakra-ui/icons";
 import { Source } from "./SourceBubble";
 import { SettingsDrawer } from "./SettingsDrawer";
 import { apiBaseUrl } from "../utils/constants";
@@ -254,9 +254,29 @@ export function ChatWindow(props: {
   // initial question helper
   const sendInitialQuestion = (q: string) => sendMessage(q);
 
+  // reset chat while keeping index and settings
+  const handleNewChat = () => {
+    setMessages([]);
+    setChatHistory([]);
+    setInput("");
+    setConversationId(uuidv4());
+    if (messageContainerRef.current) {
+      messageContainerRef.current.classList.remove("grow");
+    }
+  };
+
   return (
     <div className="flex flex-col items-center p-8 rounded grow max-h-full">
       <SettingsDrawer numDocs={numDocs} setNumDocs={setNumDocs} />
+      <IconButton
+        aria-label="start new chat"
+        title="start new chat"
+        icon={<AddIcon boxSize={6} />}
+        position="absolute"
+        top={14}
+        left={2}
+        onClick={handleNewChat}
+      />
       {messages.length > 0 ? (
         <Flex direction="column" alignItems="center" pb="20px">
           <Heading fontSize="8xl" fontWeight="medium" mb={1} color="black">

--- a/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
@@ -187,6 +187,34 @@ test("index change clears messages", async () => {
   await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue(""));
 });
 
+test("new chat button clears messages but keeps index", async () => {
+  (fetchIndexOptions as jest.Mock).mockResolvedValue([
+    { name: "idx", display_name: "Index", example_questions: ["q1"] },
+  ]);
+  (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
+    opts.onmessage?.({
+      event: "data",
+      data: JSON.stringify({ streamed_output: ["hi"], id: "1", ops: [] }),
+    });
+    opts.onmessage?.({ event: "end" });
+  });
+  render(
+    <SessionProvider session={null}>
+      <ChatWindow />
+    </SessionProvider>,
+  );
+  const select = await screen.findByRole("combobox");
+  fireEvent.change(select, { target: { value: "idx" } });
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: "hi" } });
+  fireEvent.click(screen.getByLabelText("Send"));
+  await screen.findByText("hi");
+
+  fireEvent.click(screen.getByLabelText("start new chat"));
+  await screen.findByText("q1");
+  expect(select).toHaveValue("idx");
+  expect(screen.queryByText("hi")).toBeNull();
+});
+
 test("shows loading state when session loading", () => {
   (useSession as jest.Mock).mockReturnValueOnce({
     data: null,


### PR DESCRIPTION
## Summary
- add `AddIcon` and handleNewChat logic
- render a new chat IconButton that clears chat
- test button functionality
- move button below settings icon on the left side

## Testing
- `yarn lint`
- `yarn format`
- `yarn test --coverage`
