### PR TITLE
Centralize frontend strings

### DIFF
--- a/drsearch_frontend/app/components/ChatMessageBubble.tsx
+++ b/drsearch_frontend/app/components/ChatMessageBubble.tsx
@@ -17,7 +17,7 @@ import {
   Spacer,
 } from "@chakra-ui/react";
 import { sendFeedback } from "../utils/sendFeedback";
-import { apiBaseUrl } from "../utils/constants";
+import { apiBaseUrl, UI } from "../utils/constants";
 import { InlineCitation } from "./InlineCitation";
 import DOMPurify from "dompurify";
 
@@ -249,8 +249,8 @@ export function ChatMessageBubble(props: {
       const data = await response.json();
 
       if (data.code === 400) {
-        toast.error("Unable to view trace");
-        throw new Error("Unable to view trace");
+        toast.error(UI.unableToViewTrace);
+        throw new Error(UI.unableToViewTrace);
       } else {
         const url = data.replace(/['"]+/g, "");
         window.open(url, "_blank");
@@ -334,7 +334,7 @@ export function ChatMessageBubble(props: {
                 color={"blue.300"}
                 paddingBottom={"10px"}
               >
-                Sources
+                {UI.sourcesHeader}
               </Heading>
               <HStack spacing={"10px"} maxWidth={"100%"} overflow={"auto"}>
                 {filteredSources.map((source, index) => (
@@ -367,7 +367,7 @@ export function ChatMessageBubble(props: {
           </Flex>
 
           <Heading size="lg" fontWeight="medium" color="blue.300">
-            Answer
+            {UI.answerHeader}
           </Heading>
         </>
       )}
@@ -400,7 +400,7 @@ export function ChatMessageBubble(props: {
                   setFeedbackColor("border-4 border-green-300");
                 } else {
                   /* istanbul ignore next */
-                  toast.error("You have already provided your feedback.");
+                  toast.error(UI.feedbackAlreadyGiven);
                 }
               }}
             >
@@ -418,7 +418,7 @@ export function ChatMessageBubble(props: {
                   setFeedbackColor("border-4 border-red-300");
                 } else {
                   /* istanbul ignore next */
-                  toast.error("You have already provided your feedback.");
+                  toast.error(UI.feedbackAlreadyGiven);
                 }
               }}
             >
@@ -437,7 +437,7 @@ export function ChatMessageBubble(props: {
               loadingText="🔄"
               color="black"
             >
-              🚀🚀 View trace
+              {UI.traceButtonText}
             </Button>
           </HStack>
         )}

--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -27,7 +27,7 @@ import {
 import { ArrowUpIcon } from "@chakra-ui/icons";
 import { Source } from "./SourceBubble";
 import { SettingsDrawer } from "./SettingsDrawer";
-import { apiBaseUrl } from "../utils/constants";
+import { apiBaseUrl, UI } from "../utils/constants";
 import { fetchIndexOptions, IndexOption } from "../utils/fetchIndexOptions";
 
 export function ChatWindow(props: {
@@ -46,7 +46,8 @@ export function ChatWindow(props: {
     { human: string; ai: string }[]
   >([]);
 
-  const { placeholder, titleText = "DRS ASSISTANT" } = props;
+  const { placeholder = UI.inputPlaceholder, titleText = UI.assistantTitle } =
+    props;
 
   // index selection
   const [selectedIndexName, setSelectedIndexName] = useState("");
@@ -263,14 +264,14 @@ export function ChatWindow(props: {
             {titleText}
           </Heading>
           <Heading fontSize="md" fontWeight="normal" mb={1} color="black">
-            Your DRS Assistant
+            {UI.assistantTagline}
           </Heading>
 
           {/* dropdown from backend */}
           <Select
             value={selectedIndexName}
             onChange={(e) => setSelectedIndexName(e.target.value)}
-            placeholder="Select Document Index"
+            placeholder={UI.selectIndexPlaceholder}
             mb="20px"
             width="auto"
             isDisabled={loadingOptions || (indexOptions?.length ?? 0) === 0}
@@ -359,12 +360,12 @@ export function ChatWindow(props: {
       {messages.length === 0 && (
         <footer className="flex justify-center absolute bottom-8">
           <a
-            href="https://www.leonardodrs.com/locations/airborne-intelligence-systems-fort-walton-beach/"
+            href={UI.homePageLinkUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-black flex items-center"
           >
-            View AIS‑FWB Home Page
+            {UI.homePageLinkText}
           </a>
         </footer>
       )}

--- a/drsearch_frontend/app/components/EmptyState.tsx
+++ b/drsearch_frontend/app/components/EmptyState.tsx
@@ -12,8 +12,9 @@ import {
 } from "@chakra-ui/react";
 import { Image } from "@chakra-ui/react";
 import { IndexOption } from "../utils/fetchIndexOptions";
+import { UI } from "../utils/constants";
 
-const iconSrc = "llama_cafe.ico";
+const iconSrc = UI.iconSrc;
 
 export function EmptyState(props: {
   onChoice: (question: string) => any;
@@ -61,13 +62,15 @@ export function EmptyState(props: {
       <div className="relative z-10">
         <VStack spacing={4} align="center" maxWidth="800px" width="100%">
           <Heading fontSize="8xl" fontWeight={"medium"} mb={1} color={"black"}>
-            DRS ASSISTANT
+            {UI.assistantTitle}
           </Heading>
-          <p style={{ color: "black", textAlign: "center" }}>Here to assist</p>
+          <p style={{ color: "black", textAlign: "center" }}>
+            {UI.emptyStateTagline}
+          </p>
           <Select
             value={selectedIndexName}
             onChange={(e) => setSelectedIndexName(e.target.value)}
-            placeholder="Select Document Index"
+            placeholder={UI.selectIndexPlaceholder}
             marginBottom="20px"
             width="100%"
           >

--- a/drsearch_frontend/app/components/SettingsDrawer.tsx
+++ b/drsearch_frontend/app/components/SettingsDrawer.tsx
@@ -19,6 +19,7 @@ import {
   NumberDecrementStepper,
 } from "@chakra-ui/react";
 import { SettingsIcon } from "@chakra-ui/icons";
+import { UI } from "../utils/constants";
 
 export function SettingsDrawer({
   numDocs,
@@ -31,7 +32,7 @@ export function SettingsDrawer({
   return (
     <>
       <IconButton
-        aria-label="Open settings"
+        aria-label={UI.openSettingsAriaLabel}
         icon={<SettingsIcon />}
         position="absolute"
         top={2}
@@ -42,10 +43,10 @@ export function SettingsDrawer({
         <DrawerOverlay />
         <DrawerContent>
           <DrawerCloseButton />
-          <DrawerHeader>Settings</DrawerHeader>
+          <DrawerHeader>{UI.settingsTitle}</DrawerHeader>
           <DrawerBody>
             <FormControl>
-              <FormLabel>Documents to retrieve</FormLabel>
+              <FormLabel>{UI.settingsDocsLabel}</FormLabel>
               <NumberInput
                 min={1}
                 max={5}

--- a/drsearch_frontend/app/components/SourceBubble.tsx
+++ b/drsearch_frontend/app/components/SourceBubble.tsx
@@ -4,6 +4,7 @@ import "react-toastify/dist/ReactToastify.css";
 import { Card, CardBody, Heading } from "@chakra-ui/react";
 import { sendFeedback } from "../utils/sendFeedback";
 import { convertToHttpUrlIfNeeded } from "../utils/urlUtils";
+import { UI } from "../utils/constants";
 
 export type Source = {
   url: string | undefined; // Make url optional
@@ -35,11 +36,11 @@ export function SourceBubble({
     <Card
       onClick={async () => {
         if (fileUrl) {
-          const a = document.createElement('a');
+          const a = document.createElement("a");
           a.href = fileUrl;
           a.target = "_blank";
           a.rel = "noopener noreferrer"; // Security best practice
-          a.style.display = 'none';
+          a.style.display = "none";
           document.body.appendChild(a);
           a.click();
           document.body.removeChild(a);
@@ -73,7 +74,7 @@ export function SourceBubble({
     >
       <CardBody>
         <Heading size={"sm"} fontWeight={"normal"} color={"white"}>
-          {filetitle || "Unknown Document"}
+          {filetitle || UI.unknownDocument}
         </Heading>
       </CardBody>
     </Card>

--- a/drsearch_frontend/app/page.tsx
+++ b/drsearch_frontend/app/page.tsx
@@ -1,10 +1,9 @@
 // app\page.tsx
 
-// This is the file where the actual page content (in this case, the ChatWindow) is rendered. 
-// It is the entry point for the specific route (likely the homepage / in this case). 
-// The page.tsx file defines what gets rendered on the page itself, and since it uses ChakraProvider and ChatWindow, 
+// This is the file where the actual page content (in this case, the ChatWindow) is rendered.
+// It is the entry point for the specific route (likely the homepage / in this case).
+// The page.tsx file defines what gets rendered on the page itself, and since it uses ChakraProvider and ChatWindow,
 // this is the primary entry point for rendering the core content.
-
 
 "use client";
 
@@ -12,8 +11,9 @@ import { ChatWindow } from "../app/components/ChatWindow";
 import { ToastContainer } from "react-toastify";
 import { ChakraProvider, Button, Center, Spinner } from "@chakra-ui/react";
 import { useSession, signIn } from "next-auth/react";
+import { UI } from "./utils/constants";
 
-const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED !== 'False';
+const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED !== "False";
 
 export default function Home() {
   // Always call useSession at the top level
@@ -31,12 +31,12 @@ export default function Home() {
       );
     }
 
-    if (status !== "authenticated"){
+    if (status !== "authenticated") {
       // User is not authenticated, show sign-in button
       return (
         <ChakraProvider>
           <Center height="100vh">
-            <Button onClick={() => signIn()}>Sign in</Button>
+            <Button onClick={() => signIn()}>{UI.signInButton}</Button>
           </Center>
         </ChakraProvider>
       );
@@ -48,8 +48,8 @@ export default function Home() {
     <ChakraProvider>
       <ToastContainer />
       <ChatWindow
-        titleText="DRS ASSISTANT"
-        placeholder="How do I send a ticket to IT"
+        titleText={UI.assistantTitle}
+        placeholder={UI.inputPlaceholder}
       />
     </ChakraProvider>
   );

--- a/drsearch_frontend/app/utils/constants.tsx
+++ b/drsearch_frontend/app/utils/constants.tsx
@@ -2,3 +2,27 @@
 
 export const apiBaseUrl =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8011";
+
+/** Central place for UI text and links used across the frontend */
+export const UI = {
+  assistantTitle: process.env.NEXT_PUBLIC_ASSISTANT_TITLE ?? "DRS ASSISTANT",
+  inputPlaceholder:
+    process.env.NEXT_PUBLIC_INPUT_PLACEHOLDER ?? "How do I send a ticket to IT",
+  assistantTagline: "Your DRS Assistant",
+  emptyStateTagline: "Here to assist",
+  selectIndexPlaceholder: "Select Document Index",
+  homePageLinkText: "View AIS‑FWB Home Page",
+  homePageLinkUrl:
+    "https://www.leonardodrs.com/locations/airborne-intelligence-systems-fort-walton-beach/",
+  iconSrc: "llama_cafe.ico",
+  signInButton: "Sign in",
+  settingsTitle: "Settings",
+  settingsDocsLabel: "Documents to retrieve",
+  openSettingsAriaLabel: "Open settings",
+  sourcesHeader: "Sources",
+  answerHeader: "Answer",
+  feedbackAlreadyGiven: "You have already provided your feedback.",
+  traceButtonText: "🚀🚀 View trace",
+  unableToViewTrace: "Unable to view trace",
+  unknownDocument: "Unknown Document",
+};


### PR DESCRIPTION
## Summary
- centralize UI labels and links in a constants file
- use constants in ChatWindow, EmptyState, SettingsDrawer, ChatMessageBubble, SourceBubble, and page

## Testing
- `yarn format`
- `yarn lint`
- `yarn test --coverage`
