### PR TITLE
Add vector DB backend abstraction

### DIFF
--- a/docextract/.example.env
+++ b/docextract/.example.env
@@ -1,6 +1,8 @@
 
 WEAVIATE_URL=http://localhost:8080
 WEAVIATE_API_KEY=key
+VECTOR_DB_BACKEND=weaviate
+PGVECTOR_CONNECTION=postgresql://user:password@localhost:5432/vector_db
 
 SEP_PATH_REAL=enter_document_repo_path
 SEP_PATH_DOCKER=/app/docs

--- a/docextract/ExtendedSQLRecordManager4.py
+++ b/docextract/ExtendedSQLRecordManager4.py
@@ -171,7 +171,7 @@ INGESTION ABORTED!
         self,
         vectorstore,
         namespace,
-        group_ids
+        group_ids,
     ):
         """
         Delete documents from the vector store and the record manager based on the provided namespace and list of group_ids.
@@ -186,11 +186,15 @@ INGESTION ABORTED!
         keys = self.record_manager.list_keys(group_ids=group_ids)
 
         if not keys:
-             self.logger.info(f"No keys found in the namespace {namespace} for the provided group IDs.")
+            self.logger.info(
+                f"No keys found in the namespace {namespace} for the provided group IDs."
+            )
         else:
-            # Delete keys using the record manager
+            vectorstore.delete(ids=keys)
             self.record_manager.delete_keys(keys)
-            self.logger.info(f"All keys in the namespace '{namespace}' for the provided group IDs have been deleted from the record manager.")
+            self.logger.info(
+                f"All keys in the namespace '{namespace}' for the provided group IDs have been deleted from the record manager."
+            )
 
         """
         ISSUE SUMMARY:
@@ -232,30 +236,7 @@ INGESTION ABORTED!
 
 
 
-        # Initialize Weaviate client to delete data from Weaviate
-        client = vectorstore._client
-
-        try:
-            # Retrieve and delete all object IDs in the index in batches
-            while True:
-                response = client.query.get(namespace).with_additional("id").do()
-                if 'data' in response and namespace in response['data']:
-                    objects = response['data'][namespace]
-                    if not objects:
-                        break
-
-                    for obj in objects:
-                        object_id = obj['id']
-                        client.data_object.delete(object_id)
-
-                    self.logger.info(f"Batch of {len(objects)} objects deleted from Weaviate index '{namespace}'.")
-
-                else:
-                    self.logger.info(f"No more data found in Weaviate index '{namespace}'.")
-                    break
-
-        except Exception as e:
-            self.logger.error(f"Error deleting objects from Weaviate index '{namespace}': {e}")
+        return
 
 
     def update_document_record(self, session, group_id, file_hash, last_modified, ingestion_date, **kwargs):
@@ -436,7 +417,7 @@ INGESTION ABORTED!
                         indexing_stats = index(
                             batch_elements,
                             self.record_manager,
-                            vectorstore,
+                            vectorstore.inner,
                             cleanup=cleanup,
                             source_id_key="file_path",
                             force_update=force_update,

--- a/docextract/tests/test_vector_store.py
+++ b/docextract/tests/test_vector_store.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+
+# Prepare dummy modules for vector stores
+class DummyVector:
+    def __init__(self):
+        self.deleted = []
+
+    def delete(self, ids=None):
+        self.deleted.append(ids)
+
+
+def create_dummy_weaviate_modules():
+    weaviate_mod = ModuleType("weaviate")
+    weaviate_mod.Client = mock.MagicMock(return_value="client")
+    weaviate_mod.AuthApiKey = mock.MagicMock(return_value="auth")
+    lc_mod = ModuleType("langchain_community.vectorstores")
+    lc_mod.Weaviate = mock.MagicMock(return_value=DummyVector())
+    return {"weaviate": weaviate_mod, "langchain_community.vectorstores": lc_mod}
+
+
+def create_dummy_pgvector_modules():
+    lc_mod = ModuleType("langchain_community.vectorstores")
+    lc_mod.PGVector = mock.MagicMock(return_value=DummyVector())
+    return {"langchain_community.vectorstores": lc_mod}
+
+
+@pytest.mark.parametrize("backend", ["weaviate", "pgvector"])
+def test_from_config_creates_backend(backend):
+    modules = {}
+    if backend == "weaviate":
+        modules = create_dummy_weaviate_modules()
+    else:
+        modules = create_dummy_pgvector_modules()
+    with mock.patch.dict(sys.modules, modules, clear=False):
+        env = {
+            "VECTOR_DB_BACKEND": backend,
+            "WEAVIATE_URL": "http://localhost:8080",
+            "WEAVIATE_API_KEY": "key",
+            "PGVECTOR_CONNECTION": "postgresql://user:pass@localhost/db",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            from docextract.vector_store import from_config, WeaviateVectorStore, PgVectorStore
+
+            store = from_config("idx", "text", embedding="emb")
+            if backend == "weaviate":
+                assert isinstance(store, WeaviateVectorStore)
+            else:
+                assert isinstance(store, PgVectorStore)
+
+
+def test_wrapper_delete_calls_underlying():
+    dummy = DummyVector()
+    modules = {
+        "langchain_community.vectorstores": mock.MagicMock(PGVector=mock.MagicMock(return_value=dummy))
+    }
+    with mock.patch.dict(sys.modules, modules, clear=False):
+        with mock.patch.dict(os.environ, {"VECTOR_DB_BACKEND": "pgvector", "PGVECTOR_CONNECTION": "x", "WEAVIATE_URL": "", "WEAVIATE_API_KEY": ""}):
+            from docextract.vector_store import from_config
+
+            store = from_config("idx", "text", embedding="emb")
+            store.delete(["1", "2"])
+            assert dummy.deleted == [["1", "2"]]

--- a/docextract/vector_store.py
+++ b/docextract/vector_store.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from typing import Any, List
+
+
+class BaseVectorStore(ABC):
+    """Abstract base class for vector database backends."""
+
+    @abstractmethod
+    def delete(self, ids: List[str]) -> None:
+        """Delete vectors by ids."""
+
+    @property
+    @abstractmethod
+    def inner(self) -> Any:
+        """Return underlying vector store used by LangChain."""
+
+
+class WeaviateVectorStore(BaseVectorStore):
+    """Vector store backed by Weaviate."""
+
+    def __init__(self, client: Any, index_name: str, text_key: str, embedding: Any, attributes: List[str] | None = None) -> None:
+        from langchain_community.vectorstores import Weaviate
+
+        self._store = Weaviate(
+            client=client,
+            index_name=index_name,
+            text_key=text_key,
+            embedding=embedding,
+            by_text=False,
+            attributes=attributes,
+        )
+
+    def delete(self, ids: List[str]) -> None:  # pragma: no cover - simple forwarder
+        self._store.delete(ids=ids)
+
+    @property
+    def inner(self) -> Any:  # pragma: no cover - trivial
+        return self._store
+
+
+class PgVectorStore(BaseVectorStore):
+    """Vector store backed by PostgreSQL with pgvector."""
+
+    def __init__(self, connection_string: str, collection_name: str, embedding: Any, text_key: str) -> None:
+        from langchain_community.vectorstores import PGVector
+
+        self._store = PGVector(
+            connection_string=connection_string,
+            collection_name=collection_name,
+            embedding_function=embedding,
+            text_key=text_key,
+        )
+
+    def delete(self, ids: List[str]) -> None:  # pragma: no cover - simple forwarder
+        self._store.delete(ids=ids)
+
+    @property
+    def inner(self) -> Any:  # pragma: no cover - trivial
+        return self._store
+
+
+def from_config(index_name: str, text_key: str, embedding: Any, attributes: List[str] | None = None) -> BaseVectorStore:
+    """Instantiate a vector store backend based on environment configuration."""
+    backend = os.getenv("VECTOR_DB_BACKEND", "weaviate").lower()
+
+    if backend == "pgvector":
+        connection = os.getenv("PGVECTOR_CONNECTION")
+        if not connection:
+            raise ValueError("PGVECTOR_CONNECTION environment variable not set")
+        return PgVectorStore(
+            connection_string=connection,
+            collection_name=index_name,
+            embedding=embedding,
+            text_key=text_key,
+        )
+
+    # Default to Weaviate
+    import weaviate
+
+    client = weaviate.Client(
+        url=os.getenv("WEAVIATE_URL"),
+        auth_client_secret=weaviate.AuthApiKey(os.getenv("WEAVIATE_API_KEY")),
+    )
+    return WeaviateVectorStore(
+        client=client,
+        index_name=index_name,
+        text_key=text_key,
+        embedding=embedding,
+        attributes=attributes,
+    )


### PR DESCRIPTION
## Summary
- support pgvector and Weaviate in `ExtendedSQLRecordManager4`
- add vector store abstraction and factory
- document new env vars
- add unit tests for vector store factory

## Testing
- `cd drsearch_backend && poetry run pytest --cov=app --cov-report=term-missing -q`
- `cd drsearch_frontend && yarn lint`
- `yarn format`
- `yarn test --coverage`
