### PR TITLE
Consolidate source list on hover

### DIFF
--- a/drsearch_frontend/app/components/ChatMessageBubble.tsx
+++ b/drsearch_frontend/app/components/ChatMessageBubble.tsx
@@ -5,7 +5,8 @@ import "react-toastify/dist/ReactToastify.css";
 import { emojisplosion } from "emojisplosion";
 import { useState, useRef } from "react";
 import { useSession } from "next-auth/react"; // Import useSession for authentication
-import { SourceBubble, Source } from "./SourceBubble";
+import { Source } from "./SourceBubble";
+import { SourceList } from "./SourceList";
 import {
   VStack,
   Flex,
@@ -15,6 +16,10 @@ import {
   Button,
   Divider,
   Spacer,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverBody,
 } from "@chakra-ui/react";
 import { sendFeedback } from "../utils/sendFeedback";
 import { apiBaseUrl } from "../utils/constants";
@@ -327,42 +332,39 @@ export function ChatMessageBubble(props: {
         <>
           <Flex direction={"column"} width={"100%"}>
             <VStack spacing={"5px"} align={"start"} width={"100%"}>
-              <Heading
-                fontSize="lg"
-                fontWeight={"medium"}
-                mb={1}
-                color={"blue.300"}
-                paddingBottom={"10px"}
-              >
-                Sources
-              </Heading>
-              <HStack spacing={"10px"} maxWidth={"100%"} overflow={"auto"}>
-                {filteredSources.map((source, index) => (
-                  <Box key={index} alignSelf={"stretch"} width={40}>
-                    <SourceBubble
-                      source={source}
-                      highlighted={highlighedSourceLinkStates[index]}
-                      onMouseEnter={() => {
-                        console.log(
-                          `Mouse entered SourceBubble for index ${index}`,
-                        );
+              <Popover trigger="hover" placement="bottom-start" isLazy>
+                <PopoverTrigger>
+                  <Heading
+                    fontSize="lg"
+                    fontWeight={"medium"}
+                    mb={1}
+                    color={"blue.300"}
+                    paddingBottom={"10px"}
+                    cursor="pointer"
+                  >
+                    Sources
+                  </Heading>
+                </PopoverTrigger>
+                <PopoverContent bg="rgb(45,52,62)" border="none" width="auto">
+                  <PopoverBody>
+                    <SourceList
+                      sources={filteredSources}
+                      highlightedStates={highlighedSourceLinkStates}
+                      onMouseEnter={(index) => {
                         setHighlightedSourceLinkStates(
                           filteredSources.map((_, i) => i === index),
                         );
                       }}
-                      onMouseLeave={() => {
-                        console.log(
-                          `Mouse left SourceBubble for index ${index}`,
-                        );
+                      onMouseLeave={() =>
                         setHighlightedSourceLinkStates(
                           filteredSources.map(() => false),
-                        );
-                      }}
+                        )
+                      }
                       runId={runId}
                     />
-                  </Box>
-                ))}
-              </HStack>
+                  </PopoverBody>
+                </PopoverContent>
+              </Popover>
             </VStack>
           </Flex>
 

--- a/drsearch_frontend/app/components/SourceList.tsx
+++ b/drsearch_frontend/app/components/SourceList.tsx
@@ -1,0 +1,57 @@
+import { VStack, Link } from "@chakra-ui/react";
+import { Source } from "./SourceBubble";
+import { sendFeedback } from "../utils/sendFeedback";
+import { convertToHttpUrlIfNeeded } from "../utils/urlUtils";
+
+export function SourceList({
+  sources,
+  highlightedStates,
+  onMouseEnter,
+  onMouseLeave,
+  runId,
+}: {
+  sources: Source[];
+  highlightedStates: boolean[];
+  onMouseEnter: (index: number) => void;
+  onMouseLeave: () => void;
+  runId?: string;
+}) {
+  return (
+    <VStack align="start" spacing={1}>
+      {sources.map((source, index) => {
+        const fileUrl = source.url ? convertToHttpUrlIfNeeded(source.url) : "";
+        const fileTitle = source.title || "Unknown Document";
+        return (
+          <Link
+            key={index}
+            color={highlightedStates[index] ? "blue.200" : "blue.300"}
+            onMouseEnter={() => onMouseEnter(index)}
+            onMouseLeave={onMouseLeave}
+            onClick={async () => {
+              if (fileUrl) {
+                const a = document.createElement("a");
+                a.href = fileUrl;
+                a.target = "_blank";
+                a.rel = "noopener noreferrer";
+                a.style.display = "none";
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+              }
+              if (runId) {
+                await sendFeedback({
+                  key: "user_click",
+                  runId,
+                  value: fileUrl,
+                  isExplicit: false,
+                });
+              }
+            }}
+          >
+            {fileTitle}
+          </Link>
+        );
+      })}
+    </VStack>
+  );
+}

--- a/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
@@ -236,7 +236,7 @@ describe("ChatMessageBubble component", () => {
     await waitFor(() => expect(open).not.toHaveBeenCalled());
   });
 
-  test("source bubble hover highlights", () => {
+  test("source list hover highlights", async () => {
     renderWithProviders(
       <ChatMessageBubble
         message={{
@@ -250,9 +250,11 @@ describe("ChatMessageBubble component", () => {
         messageCompleted
       />,
     );
-    const bubble = screen.getByText("Title");
-    fireEvent.mouseEnter(bubble);
-    fireEvent.mouseLeave(bubble);
+    const heading = screen.getByText("Sources");
+    fireEvent.mouseEnter(heading);
+    const link = await screen.findByText("Title");
+    fireEvent.mouseEnter(link);
+    fireEvent.mouseLeave(link);
   });
 
   test("citation fallback uses last source", () => {

--- a/drsearch_frontend/app/components/__tests__/SourceList.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/SourceList.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { SourceList } from "../SourceList";
+import { sendFeedback } from "../../utils/sendFeedback";
+
+jest.mock("../../utils/sendFeedback");
+
+const sources = [{ url: "http://example.com", title: "Example" }];
+
+it("renders source title", () => {
+  render(
+    <SourceList
+      sources={sources}
+      highlightedStates={[false]}
+      onMouseEnter={() => {}}
+      onMouseLeave={() => {}}
+    />,
+  );
+  expect(screen.getByText("Example")).toBeInTheDocument();
+});
+
+it("handles hover and click", async () => {
+  const enter = jest.fn();
+  const leave = jest.fn();
+  (sendFeedback as jest.Mock).mockResolvedValue({});
+  render(
+    <SourceList
+      sources={sources}
+      highlightedStates={[false]}
+      onMouseEnter={enter}
+      onMouseLeave={leave}
+      runId="r"
+    />,
+  );
+  const link = screen.getByText("Example");
+  fireEvent.mouseEnter(link);
+  fireEvent.mouseLeave(link);
+  expect(enter).toHaveBeenCalledWith(0);
+  expect(leave).toHaveBeenCalled();
+  fireEvent.click(link);
+  await waitFor(() =>
+    expect(sendFeedback).toHaveBeenCalledWith({
+      key: "user_click",
+      runId: "r",
+      value: sources[0].url,
+      isExplicit: false,
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
- show sources within a popover instead of separate bubbles
- support clickable list of sources via new `SourceList` component
- update ChatMessageBubble tests for popover source list
- test `SourceList` component

## Testing
- `yarn lint`
- `yarn format`
- `yarn test --coverage`
