### PR TITLE
Add pylint config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: bash -c 'cd drsearch_backend && poetry run pylint app'
+        language: system
+        pass_filenames: false
+        files: drsearch_backend/app/

--- a/drsearch_backend/.pylintrc
+++ b/drsearch_backend/.pylintrc
@@ -1,0 +1,15 @@
+[MASTER]
+ignore=tests
+
+[MESSAGES CONTROL]
+# Many files omit module docstrings intentionally.
+disable=
+    C0114, # missing-module-docstring
+    C0115, # missing-class-docstring (simple data containers)
+    C0116, # missing-function-docstring (helpers)
+    R0903, # too-few-public-methods (dataclasses)
+    R0801, # duplicate-code across modules
+    C0103  # invalid-name for CamelCase modules like System_Prompts.py
+
+[FORMAT]
+max-line-length=120

--- a/drsearch_backend/Makefile
+++ b/drsearch_backend/Makefile
@@ -1,0 +1,3 @@
+.PHONY: lint
+lint:
+	poetry run pylint app

--- a/drsearch_backend/README.md
+++ b/drsearch_backend/README.md
@@ -131,3 +131,14 @@ v2 authentication uses a self-contained ASGI middleware that:
 3. Validates every Bearer token (`RS256`, correct `aud`, correct `iss`).  
 4. Injects decoded claims into `request.state.user`.  
 5. Plays nicely with CORS, streaming responses, and a local-dev bypass flag.
+
+## Code Quality
+This project uses **pylint** for static code analysis. Run the linter with:
+
+```bash
+make lint
+```
+
+The configuration lives in `.pylintrc`. Common warnings are disabled to
+accommodate existing patterns, such as brief data container classes and
+camel-cased module names.

--- a/drsearch_backend/pyproject.toml
+++ b/drsearch_backend/pyproject.toml
@@ -33,6 +33,7 @@ httpx = "^0.27.0"
 [tool.poetry.group.dev.dependencies]
 black = "^23.9.1"
 isort = "^5.12.0"
+pylint = "^3.1.0"
 pytest = "^8.1.1"
 pytest-mock = "^3.14.0"
 pytest-cov = "^6.1.1"
@@ -42,3 +43,4 @@ python-json-logger = "^3.3.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+


### PR DESCRIPTION
## Summary
- add pylint as a dev dependency
- configure a lint command and pre-commit hook
- create a `.pylintrc` configuration
- document linting in backend README
- fix lint hook configuration

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `yarn lint`
- `poetry run pylint app` *(fails: Command not found)*