### PR TITLE
Add Azure Search vector store

### DIFF
--- a/drsearch_backend/app/chain/retriever.py
+++ b/drsearch_backend/app/chain/retriever.py
@@ -11,7 +11,7 @@ from app.vectorstores.factory import VectorStoreFactory
 
 
 class RetrieverFactory:
-    """Factory for langchain retrievers backed by Weaviate."""
+    """Factory for langchain retrievers backed by configured vector store."""
 
     @staticmethod
     def build(index_name: str) -> BaseRetriever:

--- a/drsearch_backend/app/core/chain_config.py
+++ b/drsearch_backend/app/core/chain_config.py
@@ -23,11 +23,15 @@ load_dotenv()
 #: Toggle RAG vs. plain-chatbot mode
 RAG_ON: bool = os.getenv("RAG_ON", "True").lower() == "true"
 
-#: Vector database backend to use ("weaviate" or "pgvector")
+#: Vector database backend to use ("weaviate", "pgvector", or "azure")
 _VECTOR_BACKEND: str = os.getenv("VECTOR_BACKEND", "weaviate").lower()
 
 #: Connection string for pgvector when using the PostgreSQL backend
 _PGVECTOR_URL: str = os.getenv("PGVECTOR_URL", "")
+
+#: Azure Search connection settings
+_AZURE_SEARCH_ENDPOINT: str = os.getenv("AZURE_SEARCH_ENDPOINT", "")
+_AZURE_SEARCH_KEY: str = os.getenv("AZURE_SEARCH_KEY", "")
 
 #: How many documents to pull per query when RAG_ON
 _NUMBER_OF_DOCS_RETRIEVED: int = 3

--- a/drsearch_backend/app/vectorstores/azure_store.py
+++ b/drsearch_backend/app/vectorstores/azure_store.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_community.vectorstores.azuresearch import AzureSearch as LangchainAzureSearch
+from langchain.schema.retriever import BaseRetriever
+
+from app.chain.embeddings import EmbeddingFactory
+from app.core import chain_config
+
+from . import VectorStore
+
+
+class AzureVectorStore(VectorStore):
+    """Vector store backed by Azure Cognitive Search."""
+
+    def __init__(self, index_name: str) -> None:
+        self._store = LangchainAzureSearch(
+            azure_search_endpoint=chain_config._AZURE_SEARCH_ENDPOINT,
+            azure_search_key=chain_config._AZURE_SEARCH_KEY,
+            index_name=index_name,
+            embedding_function=EmbeddingFactory.get(),
+        )
+
+    def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
+        return self._store.as_retriever(search_kwargs=search_kwargs)

--- a/drsearch_backend/app/vectorstores/factory.py
+++ b/drsearch_backend/app/vectorstores/factory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from . import VectorStore
 from .weaviate_store import WeaviateVectorStore
 from .pgvector_store import PgVectorStore
+from .azure_store import AzureVectorStore
 from app.core import chain_config
 
 
@@ -13,4 +14,6 @@ class VectorStoreFactory:
     def create(index_name: str) -> VectorStore:
         if chain_config._VECTOR_BACKEND == "pgvector":
             return PgVectorStore(index_name)
+        if chain_config._VECTOR_BACKEND == "azure":
+            return AzureVectorStore(index_name)
         return WeaviateVectorStore(index_name)

--- a/drsearch_backend/tests/conftest.py
+++ b/drsearch_backend/tests/conftest.py
@@ -19,6 +19,8 @@ _DUMMY_ENV: Dict[str, str] = {
     "AZURE_OPENAI_DEPLOYMENT_NAME": "dummy-model",
     "AZURE_OPENAI_ENDPOINT": "https://dummy-endpoint.openai.azure.com/",
     "AZURE_OPENAI_API_KEY": "dummy-key",
+    "AZURE_SEARCH_ENDPOINT": "https://dummy-search.search.windows.net",
+    "AZURE_SEARCH_KEY": "dummy-search-key",
     "VECTOR_BACKEND": "weaviate",
     "PGVECTOR_URL": "postgresql://user:pass@localhost/db",
     # RAG is enabled by default during tests
@@ -127,6 +129,14 @@ class _FakePgVector:
         return _DummyRetriever()
 
 
+class _FakeAzureStore:
+    def __init__(self, *a, **k):
+        ...
+
+    def as_retriever(self, *a, **k):
+        return _DummyRetriever()
+
+
 @pytest.fixture(autouse=True)
 def _patch_external(monkeypatch):
     # LLM & embeddings
@@ -148,6 +158,16 @@ def _patch_external(monkeypatch):
     monkeypatch.setattr(
         "app.vectorstores.pgvector_store.PGVector",
         _FakePgVector,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "langchain_community.vectorstores.azuresearch.AzureSearch",
+        _FakeAzureStore,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.vectorstores.azure_store.LangchainAzureSearch",
+        _FakeAzureStore,
         raising=False,
     )
     yield

--- a/drsearch_backend/tests/test_retriever_factory.py
+++ b/drsearch_backend/tests/test_retriever_factory.py
@@ -27,3 +27,17 @@ def test_retriever_factory_pgvector(monkeypatch):
     )
     r = RetrieverFactory.build("JACSKE_Program")
     assert isinstance(r, BaseRetriever)
+
+
+def test_retriever_factory_azure(monkeypatch):
+    monkeypatch.setattr("app.core.chain_config._VECTOR_BACKEND", "azure")
+    monkeypatch.setattr(
+        "app.core.chain_config._AZURE_SEARCH_ENDPOINT",
+        "https://dummy-search.search.windows.net",
+    )
+    monkeypatch.setattr(
+        "app.core.chain_config._AZURE_SEARCH_KEY",
+        "dummy-search-key",
+    )
+    r = RetrieverFactory.build("JACSKE_Program")
+    assert isinstance(r, BaseRetriever)


### PR DESCRIPTION
## Summary
- add Azure Search support in chain configuration
- implement AzureVectorStore and update vector store factory
- decouple retriever factory docstring from specific backend
- expand test harness for Azure Search
- verify retriever factory handles Azure backend

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6839b2b2c8508325af0e1ea2be080dd7