### PR TITLE
Baked chicken77 update frontend

### DIFF
--- a/drsearch_frontend/.prettierrc
+++ b/drsearch_frontend/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "lf"
+}

--- a/drsearch_frontend/app/error.tsx
+++ b/drsearch_frontend/app/error.tsx
@@ -1,0 +1,24 @@
+// app/error.tsx
+'use client'
+
+
+import { Providers } from '@/components/providers'
+
+interface ErrorProps { error: Error; reset: () => void }
+
+export default function ErrorPage({ error, reset }: ErrorProps) {
+  return (
+    <Providers>
+      <div className="flex flex-col items-center justify-center h-screen p-8">
+        <h1 className="text-2xl mb-4">Something went wrong</h1>
+        <pre className="mb-4 text-sm text-red-600">{error.message}</pre>
+        <button
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={() => reset()}
+        >
+          Try again
+        </button>
+      </div>
+    </Providers>
+  )
+}

--- a/drsearch_frontend/app/layout.tsx
+++ b/drsearch_frontend/app/layout.tsx
@@ -1,36 +1,31 @@
-// app\layout.tsx
-
-// This file defines the global layout structure for the app. It wraps every page and provides the overall HTML, 
-// body structure, and common layout components (such as a navigation bar, footer, or background styling). 
+// This file defines the global layout structure for the app. It wraps every page and provides the overall HTML,
+// body structure, and common layout components (such as a navigation bar, footer, or background styling).
 // It is not responsible for rendering specific page content but ensures that all child pages follow a consistent layout.
 
-"use client";
+// app/layout.tsx
+import './globals.css'
+import { Providers } from '@/components/providers'
 
-import "./globals.css";
-// import { Inter } from "next/font/google";
-import { SessionProvider } from "next-auth/react"; // Import SessionProvider
-
-// const inter = Inter({ subsets: ["latin"] });
-
-
+export const metadata = {
+  title: 'DRSearch',
+  description: 'DRSearch Assistant',
+}
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: React.ReactNode
 }) {
   return (
     <html lang="en" className="h-full">
-      <body className="inter h-full"> {/* Directly apply the .inter class */}
-        <SessionProvider>
-          <div
-            className="flex flex-col h-full md:p-8"
-            style={{ background: "rgb(212, 211, 203)" }}
-          >
-            {children}
-          </div>
-        </SessionProvider>
+      <body
+        className="inter h-full"
+        style={{ background: 'rgb(212, 211, 203)' }}
+      >
+        <div className="flex flex-col h-full md:p-8">
+          <Providers>{children}</Providers>
+        </div>
       </body>
     </html>
-  );
+  )
 }

--- a/drsearch_frontend/app/not-found.tsx
+++ b/drsearch_frontend/app/not-found.tsx
@@ -1,0 +1,18 @@
+// app/not-found.tsx
+'use client'
+
+import { Providers } from '@/components/providers'
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <Providers>
+      <div className="flex flex-col items-center justify-center h-screen p-8">
+        <h1 className="text-3xl mb-4">404 – Page Not Found</h1>
+        <Link href="/" className="text-blue-600 underline">
+          Go back home
+        </Link>
+      </div>
+    </Providers>
+  )
+}

--- a/drsearch_frontend/app/page.tsx
+++ b/drsearch_frontend/app/page.tsx
@@ -1,56 +1,45 @@
-// app\page.tsx
-
-// This is the file where the actual page content (in this case, the ChatWindow) is rendered. 
-// It is the entry point for the specific route (likely the homepage / in this case). 
-// The page.tsx file defines what gets rendered on the page itself, and since it uses ChakraProvider and ChatWindow, 
+// This is the file where the actual page content (in this case, the ChatWindow) is rendered.
+// It is the entry point for the specific route (likely the homepage / in this case).
+// The page.tsx file defines what gets rendered on the page itself, and since it uses ChakraProvider and ChatWindow,
 // this is the primary entry point for rendering the core content.
 
+// app/page.tsx
+'use client'
 
-"use client";
+import { ChatWindow } from './components/ChatWindow'
+import { ToastContainer } from 'react-toastify'
+import { Button, Center, Spinner } from '@chakra-ui/react'
+import { useSession, signIn } from 'next-auth/react'
 
-import { ChatWindow } from "../app/components/ChatWindow";
-import { ToastContainer } from "react-toastify";
-import { ChakraProvider, Button, Center, Spinner } from "@chakra-ui/react";
-import { useSession, signIn } from "next-auth/react";
-
-const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED !== 'False';
+const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED !== 'False'
 
 export default function Home() {
-  // Always call useSession at the top level
-  const { data: session, status } = useSession();
+  const { data: session, status } = useSession()
 
   if (AUTH_ENABLED) {
-    if (status === "loading") {
-      // Render a loading state while session is being fetched
+    if (status === 'loading') {
       return (
-        <ChakraProvider>
-          <Center height="100vh">
-            <Spinner size="xl" />
-          </Center>
-        </ChakraProvider>
-      );
+        <Center height="100vh">
+          <Spinner size="xl" />
+        </Center>
+      )
     }
-
-    if (status !== "authenticated"){
-      // User is not authenticated, show sign-in button
+    if (status !== 'authenticated') {
       return (
-        <ChakraProvider>
-          <Center height="100vh">
-            <Button onClick={() => signIn()}>Sign in</Button>
-          </Center>
-        </ChakraProvider>
-      );
+        <Center height="100vh">
+          <Button onClick={() => signIn()}>Sign in</Button>
+        </Center>
+      )
     }
   }
 
-  // Render the chat window regardless of authentication status when AUTH_ENABLED is False
   return (
-    <ChakraProvider>
+    <>
       <ToastContainer />
       <ChatWindow
         titleText="DRS ASSISTANT"
         placeholder="How do I send a ticket to IT"
       />
-    </ChakraProvider>
-  );
+    </>
+  )
 }

--- a/drsearch_frontend/next.config.js
+++ b/drsearch_frontend/next.config.js
@@ -1,6 +1,6 @@
-// next.config.js
-
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'standalone',
+};
 
 module.exports = nextConfig;

--- a/drsearch_frontend/src/components/providers.tsx
+++ b/drsearch_frontend/src/components/providers.tsx
@@ -1,0 +1,13 @@
+// src/components/providers.tsx
+'use client'
+
+import { SessionProvider } from 'next-auth/react'
+import { ChakraProvider } from '@chakra-ui/react'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SessionProvider>
+      <ChakraProvider>{children}</ChakraProvider>
+    </SessionProvider>
+  )
+}

--- a/drsearch_frontend/tsconfig.json
+++ b/drsearch_frontend/tsconfig.json
@@ -1,28 +1,35 @@
 {
-    "compilerOptions": {
-      "target": "es5",
-      "lib": ["dom", "dom.iterable", "esnext"],
-      "allowJs": true,
-      "skipLibCheck": true,
-      "strict": true,
-      "forceConsistentCasingInFileNames": true,
-      "noEmit": true,
-      "esModuleInterop": true,
-      "module": "esnext",
-      "moduleResolution": "bundler",
-      "resolveJsonModule": true,
-      "isolatedModules": true,
-      "jsx": "preserve",
-      "incremental": true,
-      "plugins": [
-        {
-          "name": "next"
-        }
-      ],
-      "paths": {
-        "@/*": ["./*"]
-      }
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
     },
-    "include": ["next-env.d.ts","next-auth.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-    "exclude": ["node_modules"]
-  }
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "next-auth.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### `Fix Next.js root layout, global providers, and import paths` ### 🔍 **Problem**
In the App Router architecture (Next.js 13+), `app/layout.tsx` is required to be a **server component**. However, our implementation was attempting to:

- Use `"use client"` in `app/layout.tsx`.
- Inject client-only context providers (`SessionProvider`, `ChakraProvider`) directly in the layout.

This resulted in:

- Next.js internally flipping the layout into an illegal client/server hybrid.
- Inconsistent hydration or silent errors in production.
- Violations of App Router constraints during prerendering on Azure.

### ⚠ Why it **worked locally**

Next.js’ local development server (`next dev`) uses:

- On-demand compilation.
- Partial page hydration.
- Graceful recovery from minor layout violations.

These features masked the underlying issue because pages rendered dynamically and lazily. Azure's Oryx pipeline, on the other hand, invokes `next build` with full prerendering of all routes, catching these architectural violations.

### ✅ **Fix**

- Moved all client-only context wrappers into a new component: `app/providers.tsx`.
- Restored `app/layout.tsx` to a server component.
- Wrapped all children inside `<Providers>` in layout.
- Fixed incorrect relative import of `ChatWindow` from `../app/components/...` to `./components/...`.

---

### `created providers.tsx`

### 🔍 **Problem**

Client-only React providers like `SessionProvider` and `ChakraProvider` rely on:

- `useContext`
- Hooks
- Internal state

These can **only run inside client components**. Placing them inside `app/layout.tsx` breaks App Router rules because:

- Layouts must be server components.
- `"use client"` cannot be used in the root layout.

### ⚠ Why it **worked locally**

The dev server allowed this configuration to run and lazily resolved components. However, during the full static build in Azure:

- Next.js detected client-only code in a server-only file.
- Context references returned `null`, triggering `TypeError: Cannot read properties of null (reading 'useContext')`.

### ✅ **Fix**

Create a new file:
app/providers.tsx


This cleanly isolates all client logic inside a proper `"use client"` component. It was then imported into `app/layout.tsx` and used to wrap the `children`.

---

### `Add App Router error and not-found pages to override defaults`

### 🔍 **Problem**

The application did not define:

- `app/not-found.tsx`
- `app/error.tsx`

This caused Next.js to **fallback to its legacy Pages Router defaults**, which:

- Internally import `<Html>` from `next/document` (only valid in `pages/_document.js`)
- Use `usePathname()` and other hooks outside the correct client context
- Violate App Router constraints during static prerendering

During `next build`, these errors showed up as:

```
Error: <Html> should not be imported outside of pages/_document.
TypeError: Cannot read properties of null (reading 'useContext')
```

### ⚠ Why it **worked locally**

Local development:

- Does not prerender `/404`, `/500`, or `_error` unless explicitly visited.
- Uses a hybrid rendering fallback with friendly error boundaries.

Azure’s Oryx pipeline executes:

```bash
next build
```

which:

- Statically renders all known routes.
- Triggers fallback error pages.
- Pulls in Pages Router defaults not compatible with App Router.

### ✅ **Fix**

Created two custom App Router error boundaries:

#### `app/error.tsx`
#### `app/not-found.tsx`

This prevents Next.js from falling back to its legacy Pages Router code, eliminating the `<Html>` and `useContext` violations during `next build`.

---

### `Enable standalone output mode in next.config.js`

### 🔍 **Problem**

Even after fixing layout, provider, and error-page violations, Azure's Oryx pipeline still executes a full `yarn install` + `next build` + `next start` sequence, relying on runtime inference of dependencies.

This exposes your deployment to:

- Node module version drift
- Unexpected Pages Router fallback behavior
- Uncontrolled build environment quirks

### ✅ **Fix**

Enabled **standalone output** mode in `next.config.js`:

```js
// next.config.js
const nextConfig = {
  output: 'standalone',
};

module.exports = nextConfig;
```

This instructs Next.js to:

- Build a fully self-contained app bundle in `.next/standalone`
- Include only necessary files and dependencies
- Allow you to deploy with zero runtime dependency installation
