### PR TITLE
Add retrieval gating to RAG pipeline

### DIFF
--- a/drsearch_backend/app/System_Prompts.py
+++ b/drsearch_backend/app/System_Prompts.py
@@ -7,6 +7,16 @@ You are a helpful assistant. \
 Enclose all keywords, document numbers, part numbers and phrases with backticks (`).
 """
 
+# Prompt for the retrieval gating LLM call
+RETRIEVAL_GATING_PROMPT = (
+    "You are a message classifier. Decide whether a retrieval-augmented response "
+    "is required for this message. Respond with \"yes\" if the question clearly "
+    "needs external knowledge to answer accurately (e.g., technical, medical, "
+    "or document-based questions). Respond with \"no\" if the message is "
+    "conversational, generic, or self-contained. Only return \"yes\" or \"no\" — "
+    "nothing else."
+)
+
 # RESPONSE_TEMPLATE_text_as_html_to_text_chunk= """\
 # Your task is to provide a detailed, semantically relevant description of the provided HTML. \
 # This HTML represents content extracted from DOCX and PDF files using Unstructured-IO libraries. \

--- a/drsearch_backend/app/chain/engine.py
+++ b/drsearch_backend/app/chain/engine.py
@@ -26,7 +26,7 @@ from app.chain.formatter import DocumentFormatter
 from app.chain.history import HistorySerializer
 from app.chain.mapping import PartNumberMapping
 from app.chain.retriever import RetrieverFactory
-from app.core.chain_config import _DEFAULT_INDEX, RAG_ON
+from app.core.chain_config import _DEFAULT_INDEX, RAG_ON, RETRIEVAL_GATING_ON
 from app.index_config import INDEX_CONFIG
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,9 @@ class ChatEngine:
             self._unknown_index = False
         self._mapping = PartNumberMapping(self._cfg["PN_TO_FILE_MAPPING"])
         self._llm = self._init_llm()
+        self._gating_llm = (
+            self._init_gating_llm() if RETRIEVAL_GATING_ON else None
+        )
         self._answer_chain = self._build_answer_chain()
 
     # ------------------------------------------------------------------
@@ -82,6 +85,26 @@ class ChatEngine:
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to initialise LLM: %s", exc)
+            raise
+
+    @staticmethod
+    def _init_gating_llm() -> BaseLanguageModel:
+        """Instantiate the lightweight model used for retrieval gating."""
+        try:
+            logger.info("Creating AzureChatOpenAI gating model")
+            return AzureChatOpenAI(
+                azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+                api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+                api_version=os.environ["AZURE_OPENAI_API_VERSION"],
+                temperature=0.0,
+                model=os.getenv(
+                    "AZURE_OPENAI_GATING_DEPLOYMENT_NAME",
+                    os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+                ),
+                streaming=False,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to initialise gating LLM: %s", exc)
             raise
 
     # ------------------------------------------------------------------
@@ -141,21 +164,22 @@ class ChatEngine:
         else:
             retriever = None
 
+        chatbot_context_map = RunnableMap(
+            {
+                "context": RunnableLambda(lambda _: ""),
+                "question": itemgetter("question"),
+                "chat_history": itemgetter("chat_history"),
+            }
+        )
+
+        rag_context_map: Runnable = chatbot_context_map
         if enable_retrieval and retriever and format_docs_fn:
             retriever_chain = self._build_retriever_chain(
                 retriever, format_docs_fn
             ).with_config(run_name="FindDocs")
-            context_map = RunnableMap(
+            rag_context_map = RunnableMap(
                 {
                     "context": retriever_chain,
-                    "question": itemgetter("question"),
-                    "chat_history": itemgetter("chat_history"),
-                }
-            )
-        else:
-            context_map = RunnableMap(
-                {
-                    "context": RunnableLambda(lambda _: ""),
                     "question": itemgetter("question"),
                     "chat_history": itemgetter("chat_history"),
                 }
@@ -165,13 +189,33 @@ class ChatEngine:
             streaming=True
         )
 
+        rag_chain = rag_context_map | final_step
+        chatbot_chain = chatbot_context_map | final_step
+
+        if enable_retrieval and RETRIEVAL_GATING_ON and self._gating_llm:
+            gate_prompt = ChatPromptTemplate.from_messages(
+                [
+                    ("system", System_Prompts.RETRIEVAL_GATING_PROMPT),
+                    ("human", "{question}"),
+                ]
+            )
+            gate_chain = gate_prompt | self._gating_llm | StrOutputParser()
+            gate_pred = RunnableLambda(
+                lambda d: gate_chain.invoke({"question": d["question"]})
+                .strip()
+                .lower()
+                .startswith("y")
+            )
+            context_branch = RunnableBranch((gate_pred, rag_chain), chatbot_chain)
+        else:
+            context_branch = rag_chain if enable_retrieval else chatbot_chain
+
         chain: Runnable = (
             {
                 "question": RunnableLambda(itemgetter("question")),
                 "chat_history": RunnableLambda(HistorySerializer()),
             }
-            | context_map
-            | final_step
+            | context_branch
         )
         return chain
 

--- a/drsearch_backend/app/core/chain_config.py
+++ b/drsearch_backend/app/core/chain_config.py
@@ -23,6 +23,9 @@ load_dotenv()
 #: Toggle RAG vs. plain-chatbot mode
 RAG_ON: bool = os.getenv("RAG_ON", "True").lower() == "true"
 
+#: Enable the per-message LLM gating step before running retrieval
+RETRIEVAL_GATING_ON: bool = os.getenv("RETRIEVAL_GATING_ON", "True").lower() == "true"
+
 #: Vector database backend to use ("weaviate" or "pgvector")
 _VECTOR_BACKEND: str = os.getenv("VECTOR_BACKEND", "weaviate").lower()
 

--- a/drsearch_backend/tests/test_chat_engine.py
+++ b/drsearch_backend/tests/test_chat_engine.py
@@ -18,6 +18,17 @@ class DummyLLM:
 dummy_llm = RunnableLambda(DummyLLM())
 
 
+class _ConstantLLM:
+    def __init__(self, reply: str) -> None:
+        self._reply = reply
+
+    def __call__(self, *_, **__):
+        return self._reply
+
+    def invoke(self, *_, **__):
+        return self._reply
+
+
 def test_chat_engine_unknown_index(monkeypatch):
     """Unknown index should default to chatbot-only mode."""
 
@@ -81,6 +92,10 @@ def test_chat_engine_answer_chain_simple_RAG_ON(monkeypatch):
     monkeypatch.setattr(
         "app.chain.engine.AzureChatOpenAI",
         lambda *_, **__: _fake_llm_for_answer("LLM-OK"),
+    )
+    monkeypatch.setattr(
+        "app.chain.engine.ChatEngine._init_gating_llm",
+        lambda self: _ConstantLLM("yes"),
     )
 
     eng = ChatEngine()  # default index
@@ -153,6 +168,10 @@ def test_context_map_with_retriever(monkeypatch):
         "app.chain.engine.AzureChatOpenAI",
         lambda *_, **__: _fake_llm_for_answer("answer"),
     )
+    monkeypatch.setattr(
+        "app.chain.engine.ChatEngine._init_gating_llm",
+        lambda self: _ConstantLLM("yes"),
+    )
     monkeypatch.setattr("app.chain.engine.RAG_ON", True)
     monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
 
@@ -199,6 +218,78 @@ def test_modify_docs_enriches_path(monkeypatch, tmp_path):
     chain = engine._build_retriever_chain(retriever, format_fn)
     out = chain.invoke({"question": "test", "chat_history": []})
     assert out[0].metadata["file_path"] == "\\\\server\\abc.pdf"
+
+
+def test_gating_skips_retrieval(monkeypatch):
+    monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
+    monkeypatch.setattr("app.chain.engine.RETRIEVAL_GATING_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RETRIEVAL_GATING_ON", True)
+
+    called = {"retrieved": False}
+
+    class RecordingRetriever(_DummyRetriever):
+        def _get_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
+            called["retrieved"] = True
+            return super()._get_relevant_documents(query, run_manager=run_manager)
+
+    monkeypatch.setattr(
+        "app.chain.retriever.RetrieverFactory.build",
+        lambda *_, **__: RecordingRetriever(),
+    )
+
+    monkeypatch.setattr(
+        "app.chain.engine.AzureChatOpenAI",
+        lambda *_, **__: _ConstantLLM("LLM-OK"),
+    )
+    monkeypatch.setattr(
+        "langchain.retrievers.multi_query.MultiQueryRetriever.from_llm",
+        lambda *_, **__: _DummyRetriever(),
+    )
+    monkeypatch.setattr(
+        "app.chain.engine.ChatEngine._init_gating_llm",
+        lambda self: _ConstantLLM("no"),
+    )
+
+    engine = ChatEngine("JACSKE_Program")
+
+    out = engine.answer_chain.invoke({"question": "hi", "chat_history": []})
+    assert out == "LLM-OK"
+    assert called["retrieved"] is False
+
+
+def test_gating_allows_retrieval(monkeypatch):
+    monkeypatch.setattr("app.chain.engine.RAG_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", True)
+    monkeypatch.setattr("app.chain.engine.RETRIEVAL_GATING_ON", True)
+    monkeypatch.setattr("app.core.chain_config.RETRIEVAL_GATING_ON", True)
+
+    called = {"retrieved": False}
+
+    class RecordingRetriever(_DummyRetriever):
+        def _get_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
+            called["retrieved"] = True
+            return super()._get_relevant_documents(query, run_manager=run_manager)
+
+    monkeypatch.setattr(
+        "app.chain.retriever.RetrieverFactory.build",
+        lambda *_, **__: RecordingRetriever(),
+    )
+
+    monkeypatch.setattr(
+        "app.chain.engine.AzureChatOpenAI",
+        lambda *_, **__: _fake_llm_for_answer("LLM-OK"),
+    )
+    monkeypatch.setattr(
+        "app.chain.engine.ChatEngine._init_gating_llm",
+        lambda self: _ConstantLLM("yes"),
+    )
+
+    engine = ChatEngine("JACSKE_Program")
+
+    out = engine.answer_chain.invoke({"question": "hi", "chat_history": []})
+    assert out == "LLM-OK"
+    assert called["retrieved"] is True
 
 
 # Helper to build a deterministic FakeListLLM for test scenarios


### PR DESCRIPTION
## Summary
- add env flag `RETRIEVAL_GATING_ON`
- include gating prompt constant
- update `ChatEngine` to route queries through a lightweight gating LLM
- add unit tests for gating behaviour

## Testing
- `poetry run pytest -q`
- `poetry run pylint app`

------
https://chatgpt.com/codex/tasks/task_e_683c98ad65b08325a061d1c51ff5f0d7