### PR TITLE
Update pyproject.toml

### DIFF
--- a/drsearch_backend/pyproject.toml
+++ b/drsearch_backend/pyproject.toml
@@ -1,44 +1,52 @@
-[tool.poetry]
+[project]
 name = "drsearch_backend"
 version = "0.1.0"
-description = "The frontend project for DRSearch app"
-authors = ["S <Private@me.com>"]
-license = "MIT"
+description = "The backend project for DRSearch app"
+authors = [
+  { name = "S", email = "Private@me.com" }
+]
+license = { text = "MIT" }
 readme = "README.md"
+requires-python = ">=3.11,<3.13"
+
+dependencies = [
+  "fastapi>=0.103.2",
+  "pydantic>=1.10.17",
+  "langchain==0.1.20",
+  "uvicorn>=0.23.2",
+  "tiktoken==0.7.0",
+  "lxml>=4.9.4",
+  "langserve[server]>=0.0.34",
+  "psycopg2-binary>=2.9.9",
+  "python-dotenv>=1.0.0",
+  "langchain-core==0.1.52",
+  "langchain-community==0.0.38",
+  "langchain-openai==0.1.7",
+  "weaviate-client>=3.26.5",
+  "langfuse>=2.35.0",
+  "pyjwt>=2.9.0",
+  "cryptography>=43.0.1",
+  "requests>=2.32.3",
+  "truststore>=0.10.1",
+  "python-json-logger>=3.3.0",
+  "httpx>=0.27.0",
+  "azure-core>=1.34.0",
+  "azure-search-documents>=11.5.2"
+]
+
+[project.optional-dependencies]
+dev = [
+  "black>=23.9.1",
+  "isort>=5.12.0",
+  "pytest>=8.1.1",
+  "pytest-mock>=3.14.0",
+  "pytest-cov>=6.1.1",
+  "starlette==0.27.0",
+  "python-json-logger>=3.3.0"
+]
+
+[tool.poetry]
 packages = [{ include = "app" }]
-
-[tool.poetry.dependencies]
-python = "^3.11"
-fastapi = "^0.103.2"
-pydantic = "^1.10.17"
-langchain = "0.1.20"
-uvicorn = "^0.23.2"
-tiktoken = "0.7.0"
-lxml = "^4.9.4"
-langserve = {extras = ["server"], version = "^0.0.34"}
-psycopg2-binary = "^2.9.9"
-python-dotenv = "^1.0.0"
-langchain-core = "0.1.52" 
-langchain-community = "0.0.38"
-langchain-openai = "0.1.7"
-weaviate-client = "^3.26.5"
-langfuse = "^2.35.0"
-pyjwt = "^2.9.0"
-cryptography = "^43.0.1"
-requests = "^2.32.3"
-truststore = "^0.10.1"
-python-json-logger = "^3.3.0"
-httpx = "^0.27.0"
-
-[tool.poetry.group.dev.dependencies]
-black = "^23.9.1"
-isort = "^5.12.0"
-pylint = "^3.1.0"
-pytest = "^8.1.1"
-pytest-mock = "^3.14.0"
-pytest-cov = "^6.1.1"
-starlette = "0.27.0"
-python-json-logger = "^3.3.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
migrate: Update pyproject.toml to PEP 621-compliant project metadata

- Moved metadata fields (name, version, description, etc.) to [project] table
- Converted dependencies to array-based format under [project.dependencies]
- Organized dev dependencies under [project.optional-dependencies.dev]
- Retained [tool.poetry] section only for non-standard settings (e.g., packages)
- Removed deprecated [tool.poetry.*] fields to resolve Poetry warnings