### PR TITLE
Add index warmup with status tracking

### DIFF
--- a/drsearch_backend/app/__init__.py
+++ b/drsearch_backend/app/__init__.py
@@ -9,6 +9,7 @@ from .core.config import Settings, get_settings
 from .core.logging import configure_logging
 from .auth.middleware import AuthMiddleware
 from .api.v1.routes import build_router
+from .warmup import warm_up_indexes
 from fastapi.middleware.cors import CORSMiddleware
 
 
@@ -38,6 +39,10 @@ def create_app() -> FastAPI:
 
     # -------------------- routers --------------------
     app.include_router(build_router(settings=settings))
+
+    @app.on_event("startup")
+    async def warm_up() -> None:
+        await warm_up_indexes()
 
     return app
 

--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -27,6 +27,7 @@ from app.models import (
     TraceRequest,
 )
 from ...core.logging import logging
+from app.warmup import INDEX_STATUS
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,13 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
     @router.get("/index-options", response_model=IndexOptionsResponse)
     async def index_options() -> IndexOptionsResponse:  # noqa: D401
         try:
-            opts = [IndexOption(**o) for o in await _read_index_options()]
+            raw_opts = await _read_index_options()
+            opts = [
+                IndexOption(
+                    **o, initialized=INDEX_STATUS.get(o["name"], False)
+                )
+                for o in raw_opts
+            ]
             return IndexOptionsResponse(result=opts)
         except Exception as exc:  # pragma: no cover – catastrophic
             logger.error("Unable to read index options", exc_info=exc)

--- a/drsearch_backend/app/models/shared.py
+++ b/drsearch_backend/app/models/shared.py
@@ -20,6 +20,7 @@ class IndexOption(BaseModel):
     name: str
     display_name: Optional[str] = None
     example_questions: Optional[List[str]] = None
+    initialized: bool = False
 
 
 class IndexOptionsResponse(BaseModel):

--- a/drsearch_backend/app/warmup.py
+++ b/drsearch_backend/app/warmup.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Dict
+import logging
+
+from app.index_options import INDEX_OPTIONS
+from app.chain.api import get_answer_chain
+
+logger = logging.getLogger(__name__)
+
+# Track whether each index has been successfully warmed up
+INDEX_STATUS: Dict[str, bool] = {opt["name"]: False for opt in INDEX_OPTIONS}
+
+
+async def warm_up_indexes() -> None:
+    """Initialise all indexes so first user request is fast."""
+    for index_name in INDEX_STATUS.keys():
+        try:
+            engine = get_answer_chain(index_name)
+            await engine.ainvoke({"question": "warmup", "chat_history": []})
+            INDEX_STATUS[index_name] = True
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Warm-up failed for %s", index_name, exc_info=exc)
+            INDEX_STATUS[index_name] = False
+

--- a/drsearch_backend/tests/test_api_routes.py
+++ b/drsearch_backend/tests/test_api_routes.py
@@ -9,9 +9,13 @@ async def _ok():
 
 def test_index_options_happy_path(fastapi_client: TestClient, monkeypatch):
     monkeypatch.setattr("app.api.v1.routes._read_index_options", _ok)
+    monkeypatch.setattr("app.warmup.INDEX_STATUS", {"x": True})
+    monkeypatch.setattr("app.api.v1.routes.INDEX_STATUS", {"x": True})
     r = fastapi_client.get("/index-options")
     assert r.status_code == 200
-    assert r.json()["result"][0]["name"] == "x"
+    data = r.json()["result"][0]
+    assert data["name"] == "x"
+    assert data["initialized"] is True
 
 
 def test_feedback_create_and_patch(fastapi_client: TestClient):

--- a/drsearch_backend/tests/test_warmup.py
+++ b/drsearch_backend/tests/test_warmup.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import pytest
+
+from app import warmup
+
+
+def test_warm_up_success(monkeypatch):
+    warmup.INDEX_STATUS = {"idx": False}
+
+    class Dummy:
+        async def ainvoke(self, *_):
+            return "ok"
+
+    monkeypatch.setattr(warmup, "get_answer_chain", lambda name: Dummy())
+
+    asyncio.run(warmup.warm_up_indexes())
+    assert warmup.INDEX_STATUS["idx"] is True
+
+
+def test_warm_up_failure(monkeypatch):
+    warmup.INDEX_STATUS = {"idx": False}
+
+    class Dummy:
+        async def ainvoke(self, *_):
+            raise ValueError("boom")
+
+    monkeypatch.setattr(warmup, "get_answer_chain", lambda name: Dummy())
+
+    asyncio.run(warmup.warm_up_indexes())
+    assert warmup.INDEX_STATUS["idx"] is False

--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -296,7 +296,12 @@ export function ChatWindow(props: {
             isDisabled={loadingOptions || (indexOptions?.length ?? 0) === 0}
           >
             {indexOptions?.map((opt) => (
-              <option key={opt.name} value={opt.name}>
+              <option
+                key={opt.name}
+                value={opt.name}
+                disabled={!opt.initialized}
+                className={!opt.initialized ? "text-gray-400" : ""}
+              >
                 {opt.display_name}
               </option>
             ))}

--- a/drsearch_frontend/app/components/EmptyState.tsx
+++ b/drsearch_frontend/app/components/EmptyState.tsx
@@ -72,7 +72,12 @@ export function EmptyState(props: {
             width="100%"
           >
             {indexOptions?.map((opt) => (
-              <option key={opt.name} value={opt.name}>
+              <option
+                key={opt.name}
+                value={opt.name}
+                disabled={!opt.initialized}
+                className={!opt.initialized ? "text-gray-400" : ""}
+              >
                 {opt.display_name}
               </option>
             ))}

--- a/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
@@ -56,7 +56,12 @@ jest.mock("@microsoft/fetch-event-source", () => ({
 
 test("shows options and sends initial question", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "idx", display_name: "Index", example_questions: ["q1"] },
+    {
+      name: "idx",
+      display_name: "Index",
+      example_questions: ["q1"],
+      initialized: true,
+    },
   ]);
   const mockSession = { accessToken: "token" } as any;
   render(
@@ -84,6 +89,25 @@ test("send button disabled without index", async () => {
   expect(screen.getByLabelText("Send")).toBeDisabled();
 });
 
+test("uninitialized index option disabled", async () => {
+  (fetchIndexOptions as jest.Mock).mockResolvedValue([
+    {
+      name: "idx",
+      display_name: "Index",
+      example_questions: [],
+      initialized: false,
+    },
+  ]);
+  const mockSession = { accessToken: "token" } as any;
+  render(
+    <SessionProvider session={mockSession}>
+      <ChatWindow />
+    </SessionProvider>,
+  );
+  const opt = await screen.findByRole("option", { name: "Index" });
+  expect(opt).toBeDisabled();
+});
+
 test("does not send message when index not selected", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([]);
   const mockSession = { accessToken: "token" } as any;
@@ -100,7 +124,12 @@ test("does not send message when index not selected", async () => {
 
 test("sends message and processes stream", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "idx", display_name: "Index", example_questions: ["q"] },
+    {
+      name: "idx",
+      display_name: "Index",
+      example_questions: ["q"],
+      initialized: true,
+    },
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
@@ -125,8 +154,18 @@ test("sends message and processes stream", async () => {
 
 test("changing index resets chat", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "idx", display_name: "Index", example_questions: ["q"] },
-    { name: "idx2", display_name: "Other", example_questions: ["q"] },
+    {
+      name: "idx",
+      display_name: "Index",
+      example_questions: ["q"],
+      initialized: true,
+    },
+    {
+      name: "idx2",
+      display_name: "Other",
+      example_questions: ["q"],
+      initialized: true,
+    },
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
@@ -153,8 +192,8 @@ test("changing index resets chat", async () => {
 
 test("index change clears messages", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "a", display_name: "A", example_questions: [] },
-    { name: "b", display_name: "B", example_questions: [] },
+    { name: "a", display_name: "A", example_questions: [], initialized: true },
+    { name: "b", display_name: "B", example_questions: [], initialized: true },
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
@@ -189,7 +228,12 @@ test("index change clears messages", async () => {
 
 test("new chat button clears messages but keeps index", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "idx", display_name: "Index", example_questions: ["q1"] },
+    {
+      name: "idx",
+      display_name: "Index",
+      example_questions: ["q1"],
+      initialized: true,
+    },
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
@@ -231,7 +275,12 @@ test("shows loading state when session loading", () => {
 
 test("renders highlighted markdown and updates message", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "idx", display_name: "Index", example_questions: [] },
+    {
+      name: "idx",
+      display_name: "Index",
+      example_questions: [],
+      initialized: true,
+    },
   ]);
 
   const highlightSpy = jest.spyOn(hljs, "highlight");
@@ -283,7 +332,12 @@ test("renders highlighted markdown and updates message", async () => {
 
 test("enter vs shift+enter", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "idx", display_name: "Index", example_questions: [] },
+    {
+      name: "idx",
+      display_name: "Index",
+      example_questions: [],
+      initialized: true,
+    },
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({ event: "end" });

--- a/drsearch_frontend/app/components/__tests__/EmptyState.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/EmptyState.test.tsx
@@ -6,6 +6,7 @@ const options = [
     name: "index1",
     display_name: "Index 1",
     example_questions: ["q1", "q2", "q3", "q4"],
+    initialized: true,
   },
 ];
 
@@ -62,4 +63,24 @@ test("renders all example options and handles hover and click", () => {
     expect(onChoice).toHaveBeenCalledWith(q);
   });
   expect(onChoice).toHaveBeenCalledTimes(options[0].example_questions.length);
+});
+
+test("uninitialized options are disabled", () => {
+  render(
+    <EmptyState
+      onChoice={() => {}}
+      selectedIndexName=""
+      setSelectedIndexName={() => {}}
+      indexOptions={[
+        {
+          name: "i",
+          display_name: "I",
+          example_questions: [],
+          initialized: false,
+        },
+      ]}
+      loadingOptions={false}
+    />,
+  );
+  expect(screen.getByRole("option", { name: "I" })).toBeDisabled();
 });

--- a/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
@@ -13,13 +13,17 @@ afterEach(() => {
 test("fetches index options with token", async () => {
   (fetch as jest.Mock).mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve({ code: 200, result: [{ name: "a" }] }),
+    json: () =>
+      Promise.resolve({
+        code: 200,
+        result: [{ name: "a", initialized: true }],
+      }),
   });
   const res = await fetchIndexOptions("tok");
   expect(fetch).toHaveBeenCalledWith(apiUrl, {
     headers: { Authorization: "Bearer tok" },
   });
-  expect(res).toEqual([{ name: "a" }]);
+  expect(res).toEqual([{ name: "a", initialized: true }]);
 });
 
 test("throws error on http failure", async () => {

--- a/drsearch_frontend/app/utils/fetchIndexOptions.ts
+++ b/drsearch_frontend/app/utils/fetchIndexOptions.ts
@@ -6,13 +6,16 @@ export interface IndexOption {
   name: string;
   display_name: string;
   example_questions: string[];
+  initialized: boolean;
 }
 
 /**
  * Fetch dropdown choices from the backend.
  * Adds the bearer token when AUTH is enabled.
  */
-export async function fetchIndexOptions(token?: string): Promise<IndexOption[]> {
+export async function fetchIndexOptions(
+  token?: string,
+): Promise<IndexOption[]> {
   const headers: Record<string, string> = {};
   if (token) headers["Authorization"] = `Bearer ${token}`;
 


### PR DESCRIPTION
## Summary
- warm up document indexes on startup and expose their status
- report warmup status from `/index-options`
- disable uninitialized options in the React UI
- test backend warmup and `/index-options`
- test dropdown disable logic on the frontend

## Testing
- `cd drsearch_backend && poetry run pytest --cov=app --cov-report=term-missing -q`
- `cd drsearch_frontend && yarn lint`
- `yarn format`
- `yarn test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68419f609964832583f5ca25ff091964