### PR TITLE
Add document list sidebar feature

### DIFF
--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Response
 from fastapi.responses import FileResponse
+import psycopg2
+from psycopg2.extras import RealDictCursor
 from langserve import add_routes
 
 from ...core.config import Settings, get_settings
@@ -23,6 +25,7 @@ from app.models import (
     FeedbackUpdate,
     IndexOption,
     IndexOptionsResponse,
+    DocumentListResponse,
     StandardResponse,
     TraceRequest,
 )
@@ -66,6 +69,24 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
         except Exception as exc:  # pragma: no cover – catastrophic
             logger.error("Unable to read index options", exc_info=exc)
             raise HTTPException(status_code=500, detail="Unable to read index options") from exc
+
+    # ---- /documents
+    @router.get("/documents", response_model=DocumentListResponse)
+    async def document_list(index: str) -> DocumentListResponse:  # noqa: D401
+        db_url = os.getenv("RECORD_MANAGER_DB_URL")
+        if not db_url:
+            raise HTTPException(status_code=500, detail="Database URL not configured")
+        try:
+            with psycopg2.connect(db_url) as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    "SELECT DISTINCT group_id FROM doc_records WHERE namespace = %s",
+                    (index,),
+                )
+                rows = cur.fetchall()
+            return DocumentListResponse(result=[r["group_id"] for r in rows])
+        except Exception as exc:  # pragma: no cover – catastrophic
+            logger.error("Unable to fetch document list", exc_info=exc)
+            raise HTTPException(status_code=500, detail="Unable to read document list") from exc
 
     # ---- feedback endpoints -------------------------------------------------
     @router.post("/feedback", status_code=200, response_model=StandardResponse)

--- a/drsearch_backend/app/models/__init__.py
+++ b/drsearch_backend/app/models/__init__.py
@@ -3,7 +3,12 @@
 from .chat import ChatRequest
 from .feedback import Feedback, FeedbackUpdate
 from .trace import TraceRequest
-from .shared import StandardResponse, IndexOption, IndexOptionsResponse
+from .shared import (
+    StandardResponse,
+    IndexOption,
+    IndexOptionsResponse,
+    DocumentListResponse,
+)
 
 __all__ = [
     "ChatRequest",
@@ -13,5 +18,6 @@ __all__ = [
     "StandardResponse",
     "IndexOption",
     "IndexOptionsResponse",
+    "DocumentListResponse",
 ]
 

--- a/drsearch_backend/app/models/shared.py
+++ b/drsearch_backend/app/models/shared.py
@@ -28,3 +28,10 @@ class IndexOptionsResponse(BaseModel):
     result: List[IndexOption]
     code: int = Field(200, description="Application level status code")
 
+
+class DocumentListResponse(BaseModel):
+    """Response model for `/documents`."""
+
+    result: List[str]
+    code: int = Field(200, description="Application level status code")
+

--- a/drsearch_backend/tests/test_api_routes.py
+++ b/drsearch_backend/tests/test_api_routes.py
@@ -77,3 +77,35 @@ def test_patch_feedback_null_id(fastapi_client):
     r = fastapi_client.patch("/feedback", json=body)
     assert r.status_code == 400
     assert r.json()["detail"] == "Missing feedback_id"
+
+
+def test_document_list_endpoint(fastapi_client: TestClient, monkeypatch):
+    class DummyCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def execute(self, *a, **k):
+            pass
+
+        def fetchall(self):
+            return [{"group_id": "a.pdf"}, {"group_id": "b.pdf"}]
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def cursor(self, cursor_factory=None):
+            return DummyCursor()
+
+    monkeypatch.setenv("RECORD_MANAGER_DB_URL", "dummy")
+    monkeypatch.setattr("psycopg2.connect", lambda *_a, **_k: DummyConn())
+
+    r = fastapi_client.get("/documents?index=X")
+    assert r.status_code == 200
+    assert r.json()["result"] == ["a.pdf", "b.pdf"]

--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -267,7 +267,12 @@ export function ChatWindow(props: {
 
   return (
     <div className="flex flex-col items-center p-8 rounded grow max-h-full">
-      <SettingsDrawer numDocs={numDocs} setNumDocs={setNumDocs} />
+      <SettingsDrawer
+        numDocs={numDocs}
+        setNumDocs={setNumDocs}
+        indexOptions={indexOptions}
+        token={AUTH_ENABLED ? accessToken : undefined}
+      />
       <IconButton
         aria-label="start new chat"
         title="start new chat"

--- a/drsearch_frontend/app/components/SettingsDrawer.tsx
+++ b/drsearch_frontend/app/components/SettingsDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import {
   Drawer,
   DrawerOverlay,
@@ -17,17 +17,42 @@ import {
   NumberInputStepper,
   NumberIncrementStepper,
   NumberDecrementStepper,
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  ModalFooter,
+  Select,
+  Text,
+  VStack,
+  Spinner,
 } from "@chakra-ui/react";
 import { SettingsIcon } from "@chakra-ui/icons";
+import { fetchDocumentList } from "../utils/fetchDocumentList";
 
 export function SettingsDrawer({
   numDocs,
   setNumDocs,
+  indexOptions,
+  token,
 }: {
   numDocs: number;
   setNumDocs: (v: number) => void;
+  indexOptions: { name: string; display_name: string }[] | null;
+  token?: string;
 }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: modalOpen,
+    onOpen: openModal,
+    onClose: closeModal,
+  } = useDisclosure();
+  const [selectedIndex, setSelectedIndex] = useState("");
+  const [docs, setDocs] = useState<string[]>([]);
+  const [loadingDocs, setLoadingDocs] = useState(false);
   return (
     <>
       <IconButton
@@ -59,9 +84,66 @@ export function SettingsDrawer({
                 </NumberInputStepper>
               </NumberInput>
             </FormControl>
+            <Button
+              mt={4}
+              onClick={openModal}
+              isDisabled={(indexOptions?.length ?? 0) === 0}
+            >
+              Get Document List
+            </Button>
           </DrawerBody>
         </DrawerContent>
       </Drawer>
+      <Modal isOpen={modalOpen} onClose={closeModal} size="xl">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Documents</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Select
+              placeholder="Select Index"
+              mb={4}
+              value={selectedIndex}
+              onChange={(e) => setSelectedIndex(e.target.value)}
+            >
+              {indexOptions?.map((o) => (
+                <option key={o.name} value={o.name}>
+                  {o.display_name}
+                </option>
+              ))}
+            </Select>
+            {loadingDocs ? (
+              <Spinner />
+            ) : (
+              <VStack align="start" spacing={1} maxH="300px" overflowY="auto">
+                {docs.map((d) => (
+                  <Text key={d}>{d}</Text>
+                ))}
+              </VStack>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              mr={3}
+              onClick={async () => {
+                if (!selectedIndex) return;
+                setLoadingDocs(true);
+                try {
+                  const list = await fetchDocumentList(selectedIndex, token);
+                  setDocs(list);
+                } catch (e: any) {
+                  console.error(e);
+                } finally {
+                  setLoadingDocs(false);
+                }
+              }}
+            >
+              Fetch
+            </Button>
+            <Button onClick={closeModal}>Close</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/drsearch_frontend/app/utils/__tests__/fetchDocumentList.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/fetchDocumentList.test.ts
@@ -1,0 +1,57 @@
+import { fetchDocumentList } from "../fetchDocumentList";
+
+const apiUrl = "http://localhost:8011/documents?index=test";
+
+beforeEach(() => {
+  (global.fetch as any) = jest.fn();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test("fetches document list with token", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ code: 200, result: ["a"] }),
+  });
+  const res = await fetchDocumentList("test", "tok");
+  expect(fetch).toHaveBeenCalledWith(apiUrl, {
+    headers: { Authorization: "Bearer tok" },
+  });
+  expect(res).toEqual(["a"]);
+});
+
+test("throws error on http failure", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status: 500,
+    text: () => Promise.resolve("fail"),
+    statusText: "error",
+  });
+  await expect(fetchDocumentList("test")).rejects.toThrow(
+    "Failed to fetch document list: 500 – fail",
+  );
+});
+
+test("uses statusText when error body empty", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    status: 404,
+    text: () => Promise.resolve(""),
+    statusText: "Not Found",
+  });
+  await expect(fetchDocumentList("test")).rejects.toThrow(
+    "Failed to fetch document list: 404 – Not Found",
+  );
+});
+
+test("throws error on malformed data", async () => {
+  (fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ code: 400, result: null }),
+  });
+  await expect(fetchDocumentList("test")).rejects.toThrow(
+    "Backend returned malformed data",
+  );
+});

--- a/drsearch_frontend/app/utils/fetchDocumentList.ts
+++ b/drsearch_frontend/app/utils/fetchDocumentList.ts
@@ -1,0 +1,31 @@
+// app\utils\fetchDocumentList.ts
+
+import { apiBaseUrl } from "./constants";
+
+/**
+ * Fetch list of documents for a given index.
+ */
+export async function fetchDocumentList(
+  index: string,
+  token?: string,
+): Promise<string[]> {
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const r = await fetch(
+    `${apiBaseUrl}/documents?index=${encodeURIComponent(index)}`,
+    {
+      headers,
+    },
+  );
+  if (!r.ok) {
+    const text = await r.text();
+    throw new Error(
+      `Failed to fetch document list: ${r.status} – ${text || r.statusText}`,
+    );
+  }
+  const data = await r.json();
+  if (data.code !== 200 || !Array.isArray(data.result))
+    throw new Error("Backend returned malformed data");
+  return data.result as string[];
+}


### PR DESCRIPTION
## Summary
- expose a `/documents` endpoint on backend to list docs per index
- provide a response model for document lists
- add frontend util to fetch documents
- extend `SettingsDrawer` with button & modal for document list
- pass token and index options from `ChatWindow`
- test new API route and fetch helper

## Testing
- `yarn lint`
- `yarn format`
- `yarn test --coverage`
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68470f54325c8325a9c428ffe009b02d