### PR TITLE
Package drsearch_backend

### DIFF
--- a/drsearch_backend/drsearch_backend/__init__.py
+++ b/drsearch_backend/drsearch_backend/__init__.py
@@ -1,0 +1,3 @@
+import importlib, sys
+# Map drsearch_backend.app to the existing top-level 'app' package
+sys.modules[__name__ + '.app'] = importlib.import_module('app')

--- a/drsearch_backend/pyproject.toml
+++ b/drsearch_backend/pyproject.toml
@@ -49,7 +49,10 @@ dev = [
 ]
 
 [tool.poetry]
-packages = [{ include = "app" }]
+packages = [
+  { include = "app" },
+  { include = "drsearch_backend" }
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- add a package wrapper so `drsearch_backend.app` can be imported
- include new package in the Poetry config

## Testing
- `LOG_OUTPUT_MODE=local AZURE_STORAGE_CONNECTION_STRING="UseDevelopmentStorage=true" poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6849df6991ec832588b1b71e71f86629