### PR TITLE
Ensure full schema parity in Weaviate transfer

### DIFF
--- a/drsearch_backend/app/vectorstores/pgvector_store.py
+++ b/drsearch_backend/app/vectorstores/pgvector_store.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable
 
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain.schema.retriever import BaseRetriever
 
 from app.chain.embeddings import EmbeddingFactory
 from app.core import chain_config
+from app.index_config import INDEX_CONFIG
 
 from . import VectorStore
 
@@ -15,6 +16,8 @@ class PgVectorStore(VectorStore):
     """Vector store backed by PostgreSQL with pgvector."""
 
     def __init__(self, index_name: str) -> None:
+        cfg = INDEX_CONFIG[index_name]
+        self._attributes: Iterable[str] = cfg["attributes"]
         self._store = PGVector(
             connection_string=chain_config._PGVECTOR_URL,
             embedding_function=EmbeddingFactory.get(),
@@ -22,4 +25,28 @@ class PgVectorStore(VectorStore):
         )
 
     def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
-        return self._store.as_retriever(search_kwargs=search_kwargs)
+        """Return retriever while normalising filters and metadata output."""
+
+        kw = dict(search_kwargs)
+        if "where_filter" in kw:
+            kw["filter"] = kw.pop("where_filter")
+
+        base = self._store.as_retriever(search_kwargs=kw)
+
+        allowed = set(self._attributes)
+
+        def _strip(docs):
+            for doc in docs:
+                doc.metadata = {k: v for k, v in doc.metadata.items() if k in allowed}
+            return docs
+
+        class _FilteredRetriever(BaseRetriever):
+            def _get_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
+                docs = base.get_relevant_documents(query, callbacks=run_manager)
+                return _strip(docs)
+
+            async def _aget_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
+                docs = await base.aget_relevant_documents(query, callbacks=run_manager)
+                return _strip(docs)
+
+        return _FilteredRetriever()

--- a/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
+++ b/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import Sequence
@@ -16,10 +17,35 @@ logger = logging.getLogger(__name__)
 
 _INDEX2TRANSFER = "SEPS"
 _PRE_DELETE_COLLECTION = True
-_WEAVIATE_URL="http://localhost:8080" #os.environ["WEAVIATE_URL"]
+_WEAVIATE_URL = "http://localhost:8080"  # os.environ["WEAVIATE_URL"]
+
+
+def _load_schema(schema_file: str) -> tuple[list[str], dict[str, dict]]:
+    """Load property names and config from a Weaviate schema JSON file."""
+    with open(schema_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    props = data.get("result", data.get("properties", []))
+    attrs: list[str] = []
+    config: dict[str, dict] = {}
+    for prop in props:
+        name = prop.get("name")
+        if not name:
+            continue
+        attrs.append(name)
+        config[name] = {
+            "data_type": prop.get("dataType"),
+            "index_filterable": prop.get("indexFilterable"),
+            "index_searchable": prop.get("indexSearchable"),
+        }
+    return attrs, config
+
 
 def _fetch_weaviate_docs(
-    client: weaviate.Client, index: str, text_key: str, attrs: Sequence[str], batch_size: int = 100
+    client: weaviate.Client,
+    index: str,
+    text_key: str,
+    attrs: Sequence[str],
+    batch_size: int = 100,
 ) -> list[dict]:
     """Fetch all matching documents (including embeddings) from Weaviate using pagination."""
     fields = [text_key, *attrs]
@@ -30,7 +56,9 @@ def _fetch_weaviate_docs(
         result = (
             client.query.get(index, fields)
             .with_additional(["id", "vector"])
-            .with_where({"path": ["use4RAG"], "operator": "Equal", "valueBoolean": True})
+            .with_where(
+                {"path": ["use4RAG"], "operator": "Equal", "valueBoolean": True}
+            )
             .with_limit(batch_size)
             .with_offset(offset)
             .do()
@@ -45,7 +73,11 @@ def _fetch_weaviate_docs(
 
 
 def _upload_docs(
-    store: PGVector, docs: list[dict], text_key: str, attrs: Sequence[str]
+    store: PGVector,
+    docs: list[dict],
+    text_key: str,
+    attrs: Sequence[str],
+    schema: dict[str, dict],
 ) -> None:
     """Upload precomputed embeddings and metadata into the pgvector store in one batch."""
     texts: list[str] = []
@@ -56,7 +88,9 @@ def _upload_docs(
     for doc in docs:
         texts.append(doc.get(text_key, ""))
         embeddings.append(doc["_additional"]["vector"])
-        metadatas.append({a: doc.get(a) for a in attrs})
+        meta = {a: doc.get(a) for a in attrs}
+        meta["_schema"] = schema
+        metadatas.append(meta)
         ids.append(doc["_additional"]["id"])
 
     store.add_embeddings(
@@ -70,9 +104,7 @@ def _upload_docs(
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
-    index_name = os.getenv(
-        "INDEX_NAME", os.getenv("WEAVIATE_INDEX", _INDEX2TRANSFER)
-    )
+    index_name = os.getenv("INDEX_NAME", os.getenv("WEAVIATE_INDEX", _INDEX2TRANSFER))
     conn_str = os.environ["PGVECTOR_URL"]
     dimension = int(os.getenv("PGVECTOR_DIMENSION", "1536"))
 
@@ -85,12 +117,20 @@ def main() -> None:
         auth_client_secret=weaviate.AuthApiKey(os.environ["WEAVIATE_API_KEY"]),
     )
 
-    store = create_collection_if_missing(conn_str, index_name, dimension,pre_delete_collection=_PRE_DELETE_COLLECTION)
+    store = create_collection_if_missing(
+        conn_str,
+        index_name,
+        dimension,
+        pre_delete_collection=_PRE_DELETE_COLLECTION,
+    )
 
-    docs = _fetch_weaviate_docs(client, index_name, cfg["index_key"], cfg["attributes"])
+    schema_file = os.getenv("WEAVIATE_SCHEMA_FILE", "docs/weaviate_schema.json")
+    attrs, schema_cfg = _load_schema(schema_file)
+
+    docs = _fetch_weaviate_docs(client, index_name, cfg["index_key"], attrs)
     logger.info("Fetched %s documents from Weaviate", len(docs))
 
-    _upload_docs(store, docs, cfg["index_key"], cfg["attributes"])
+    _upload_docs(store, docs, cfg["index_key"], attrs, schema_cfg)
     logger.info("Transfer complete: %s documents uploaded", len(docs))
 
 


### PR DESCRIPTION
## Summary
- pull schema details from `WEAVIATE_SCHEMA_FILE`
- upload all document attributes and embed schema configuration in metadata
- keep transfer script compatible with existing setup

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae7f396f4832597ccf135eabab6ed