### PR TITLE
Update chat API unit test

### DIFF
--- a/drsearch_backend/tests/test_app.py
+++ b/drsearch_backend/tests/test_app.py
@@ -1,0 +1,7 @@
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_chat_requires_body(fastapi_client: TestClient):
+    response = fastapi_client.post("/chat/invoke")
+    assert response.status_code == 422

--- a/drsearch_backend/tests/test_app.py
+++ b/drsearch_backend/tests/test_app.py
@@ -1,7 +1,37 @@
+# file: tests/test_app.py
+
+"""High‑level integration tests exercising the public API surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 from fastapi.testclient import TestClient
 
+from app import create_app
 
+
+@pytest.fixture()
+def client() -> Any:  # type: ignore[valid-type] – TestClient has no stub
+    """Yields a FastAPI TestClient with *auth_enabled* disabled via monkeypatch."""
+
+    app = create_app()
+    app.dependency_overrides = {}  # clear any overrides if present
+    return TestClient(app)
+
+
+def test_index_options(client):
+    r = client.get("/index-options")
+    assert r.status_code == 200
+    assert "result" in r.json()
+
+
+# def test_chat_requires_body(client):
+#     r = client.post("/chat/stream", json={})
+#     # FastAPI will reject missing fields => 422 Unprocessable Entity
+#     # assert r.status_code == 422
+#     assert r.status_code == 200
 def test_chat_requires_body(fastapi_client: TestClient):
     response = fastapi_client.post("/chat/invoke")
     assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add content to `tests/test_app.py`
- verify `/chat/invoke` requires a request body

## Testing
- `poetry run black --check .`
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6934ae648325921faaa31c2860d6