### PR TITLE
Fix DocumentFormatter dedup ordering

### DIFF
--- a/drsearch_backend/app/chain/formatter.py
+++ b/drsearch_backend/app/chain/formatter.py
@@ -9,7 +9,7 @@ from langchain_community.document_transformers import LongContextReorder
 from langchain.schema import Document
 
 from app.chain.mapping import PartNumberMapping
-from app.core.chain_config import RAG_ON
+from app.core import chain_config
 
 
 class DocumentFormatter:
@@ -17,11 +17,15 @@ class DocumentFormatter:
 
     def __init__(self, mapping: PartNumberMapping):
         self._mapping = mapping.data
-        self._reorder = LongContextReorder() if RAG_ON else None
+        self._reorder = LongContextReorder() if chain_config.RAG_ON else None
 
     def __call__(self, docs: Sequence[Document]) -> str:
         """Return prompt-ready <doc/> XML fragments."""
-        unique_docs = list(OrderedDict((d.page_content, d) for d in docs).values())
+        unique_map = OrderedDict()
+        for d in docs:
+            if d.page_content not in unique_map:
+                unique_map[d.page_content] = d
+        unique_docs = list(unique_map.values())
         docs_reordered = (
             self._reorder.transform_documents(unique_docs) if self._reorder else unique_docs
         )

--- a/drsearch_backend/tests/test_document_formatter.py
+++ b/drsearch_backend/tests/test_document_formatter.py
@@ -1,4 +1,7 @@
 from langchain.schema import Document
+import os
+
+os.environ["AZURE_STORAGE_CONNECTION_STRING"] = ""
 
 from app.chain.formatter import DocumentFormatter
 from app.chain.mapping import PartNumberMapping
@@ -31,3 +34,17 @@ def test_formatter_deduplicates_and_adds_mapping(tmp_path, monkeypatch):
     # assert "\\\\share\\abc.pdf" in out
     # UNC path injected into metadata, not the xml string
     assert formatter._mapping["abc.pdf"] == "\\\\share\\abc.pdf"
+
+
+def test_formatter_prefers_html(monkeypatch):
+    """HTML documents should be preferred when content is duplicated."""
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", False)
+    formatter = DocumentFormatter(PartNumberMapping(None))
+    docs = [
+        Document(page_content="same", metadata={"filename": "doc.html"}),
+        Document(page_content="same", metadata={"filename": "doc.pdf"}),
+    ]
+
+    out = formatter(docs)
+
+    assert out.startswith("<doc id='0' source='doc.html'>")


### PR DESCRIPTION
## Summary
- keep the first occurrence when deduplicating documents
- reference chain_config.RAG_ON dynamically
- ensure tests patch RAG_ON and Azure blob env var
- add regression test for HTML preference

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6937fc28832589f8b9ead2af2f99