### PR TITLE
Improve transfer script logging

### DIFF
--- a/drsearch_backend/scripts/debug_weaviate_transfer.py
+++ b/drsearch_backend/scripts/debug_weaviate_transfer.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Debug utility for Weaviate->PGVector transfers.
+Shows class existence, schema, counts, and sample docs so you can see
+why a class might appear empty when filtered by use4RAG = True.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from textwrap import shorten
+
+import weaviate
+
+
+def connect() -> weaviate.Client:
+    url = os.getenv("WEAVIATE_URL", "http://localhost:8080")
+    api_key = os.getenv("WEAVIATE_API_KEY", "")
+    logging.info("Connecting to Weaviate at %s", url)
+    return weaviate.Client(url=url, auth_client_secret=weaviate.AuthApiKey(api_key))
+
+
+def get_class_schema(client: weaviate.Client, class_name: str) -> dict | None:
+    schema = client.schema.get()
+    for cls in schema.get("classes", []):
+        if cls["class"] == class_name:
+            return cls
+    return None
+
+
+def meta_count(client: weaviate.Client, class_name: str, where: dict | None = None) -> int:
+    q = client.query.aggregate(class_name).with_meta_count()
+    if where:
+        q = q.with_where(where)
+    resp = q.do()
+    return resp["data"]["Aggregate"][class_name][0]["meta"]["count"]
+
+
+def sample_docs(client: weaviate.Client, class_name: str, limit: int = 3) -> list[dict]:
+    resp = (
+        client.query.get(class_name, ["use4RAG"])
+        .with_additional(["id"])
+        .with_limit(limit)
+        .do()
+    )
+    return resp["data"]["Get"].get(class_name, [])
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    class_name = sys.argv[1] if len(sys.argv) > 1 else os.getenv("INDEX_NAME", "JACSKE_Program")
+
+    client = connect()
+
+    cls_schema = get_class_schema(client, class_name)
+    if cls_schema is None:
+        logging.error("Class '%s' not found in Weaviate schema.", class_name)
+        sys.exit(1)
+
+    logging.info("Class '%s' found with %d properties.", class_name, len(cls_schema["properties"]))
+    for p in cls_schema["properties"]:
+        logging.info("  %-20s type=%s", p["name"], p["dataType"])
+
+    total = meta_count(client, class_name)
+    with_flag = meta_count(
+        client,
+        class_name,
+        {"path": ["use4RAG"], "operator": "Equal", "valueBoolean": True},
+    )
+    logging.info("Total objects         : %d", total)
+    logging.info("Objects with use4RAG=T: %d", with_flag)
+
+    logging.info("Sample objects (id / use4RAG):")
+    for doc in sample_docs(client, class_name):
+        logging.info("  %-40s %s", doc["_additional"]["id"], doc.get("use4RAG"))
+
+    if with_flag == 0 and total > 0:
+        logging.warning(
+            "Objects exist but none match use4RAG=True – check spelling/casing or data type."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
+++ b/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
@@ -1,8 +1,7 @@
-"""Transfer data from Weaviate to a pgvector collection."""
+"""Transfer data from Weaviate to a pgvector collection (schema pulled live)."""
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Sequence
@@ -15,11 +14,14 @@ from scripts.create_pgvector_index import create_collection_if_missing
 
 logger = logging.getLogger(__name__)
 
-_INDEX2TRANSFER = "SEPS"
+_INDEX2TRANSFER = "JACSKE_Program"
 _PRE_DELETE_COLLECTION = True
-_WEAVIATE_URL = os.getenv("WEAVIATE_URL", "http://localhost:8080")
+_WEAVIATE_URL = "http://localhost:8080"  # os.environ["WEAVIATE_URL"]
 
 
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
 def _configure_logging() -> None:
     """Configure module logging from environment."""
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -30,27 +32,27 @@ def _configure_logging() -> None:
     )
 
 
-def _load_schema(schema_file: str, text_key: str) -> tuple[list[str], dict[str, dict]]:
-    """Load property names and config from a Weaviate schema JSON file.
-
-    Parameters
-    ----------
-    schema_file: str
-        Path to the exported Weaviate schema JSON file.
-    text_key: str
-        Name of the property that stores the document text. This field is
-        excluded from the returned attribute list so it can be stored in the
-        ``document`` column rather than metadata.
+def _extract_schema(
+    client: weaviate.Client,
+    class_name: str,
+    text_key: str,
+) -> tuple[list[str], dict[str, dict]]:
     """
-    with open(schema_file, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    props = data.get("result", data.get("properties", []))
-    logger.debug("Loaded %d schema properties", len(props))
+    Pull the class schema directly from Weaviate and return:
+
+    * attrs   – list of non-text_key property names (for metadata fetching)
+    * config  – dict mapping property → minimal config details (stored in PG)
+    """
+    class_schema = client.schema.get(class_name)
+    if not class_schema:
+        raise ValueError(f"Class '{class_name}' not found in Weaviate schema")
+
     attrs: list[str] = []
     config: dict[str, dict] = {}
-    for prop in props:
+
+    for prop in class_schema.get("properties", []):
         name = prop.get("name")
-        if not name:
+        if not name:  # defensive – should never be missing
             continue
         if name != text_key:
             attrs.append(name)
@@ -59,6 +61,7 @@ def _load_schema(schema_file: str, text_key: str) -> tuple[list[str], dict[str, 
             "index_filterable": prop.get("indexFilterable"),
             "index_searchable": prop.get("indexSearchable"),
         }
+
     return attrs, config
 
 
@@ -127,12 +130,16 @@ def _upload_docs(
     )
 
 
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
 def main() -> None:
     _configure_logging()
 
     index_name = os.getenv("INDEX_NAME", os.getenv("WEAVIATE_INDEX", _INDEX2TRANSFER))
     conn_str = os.environ["PGVECTOR_URL"]
     dimension = int(os.getenv("PGVECTOR_DIMENSION", "1536"))
+
     logger.info(
         "Starting transfer for index '%s' using Weaviate at %s", index_name, _WEAVIATE_URL
     )
@@ -156,9 +163,8 @@ def main() -> None:
     )
     logger.debug("PGVector collection '%s' ready", index_name)
 
-    schema_file = os.getenv("WEAVIATE_SCHEMA_FILE", r"scripts\weaviate_schema.json")
-    logger.debug("Loading schema from %s", schema_file)
-    attrs, schema_cfg = _load_schema(schema_file, cfg["index_key"])
+    logger.debug("Fetching schema for '%s' directly from Weaviate", index_name)
+    attrs, schema_cfg = _extract_schema(client, index_name, cfg["index_key"])
     logger.debug("Schema loaded with %s attributes", len(attrs))
 
     logger.debug("Fetching documents from Weaviate")

--- a/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
+++ b/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 _INDEX2TRANSFER = "SEPS"
 _PRE_DELETE_COLLECTION = True
-_WEAVIATE_URL = "http://localhost:8080"  # os.environ["WEAVIATE_URL"]
+_WEAVIATE_URL = os.getenv("WEAVIATE_URL", "http://localhost:8080")
 
 
 def _configure_logging() -> None:
@@ -133,6 +133,9 @@ def main() -> None:
     index_name = os.getenv("INDEX_NAME", os.getenv("WEAVIATE_INDEX", _INDEX2TRANSFER))
     conn_str = os.environ["PGVECTOR_URL"]
     dimension = int(os.getenv("PGVECTOR_DIMENSION", "1536"))
+    logger.info(
+        "Starting transfer for index '%s' using Weaviate at %s", index_name, _WEAVIATE_URL
+    )
     logger.debug("Using index '%s' with dimension %s", index_name, dimension)
 
     cfg = INDEX_CONFIG.get(index_name)

--- a/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
+++ b/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
@@ -20,6 +20,16 @@ _PRE_DELETE_COLLECTION = True
 _WEAVIATE_URL = "http://localhost:8080"  # os.environ["WEAVIATE_URL"]
 
 
+def _configure_logging() -> None:
+    """Configure module logging from environment."""
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+
 def _load_schema(schema_file: str, text_key: str) -> tuple[list[str], dict[str, dict]]:
     """Load property names and config from a Weaviate schema JSON file.
 
@@ -35,6 +45,7 @@ def _load_schema(schema_file: str, text_key: str) -> tuple[list[str], dict[str, 
     with open(schema_file, "r", encoding="utf-8") as f:
         data = json.load(f)
     props = data.get("result", data.get("properties", []))
+    logger.debug("Loaded %d schema properties", len(props))
     attrs: list[str] = []
     config: dict[str, dict] = {}
     for prop in props:
@@ -75,6 +86,7 @@ def _fetch_weaviate_docs(
             .do()
         )
         docs = result.get("data", {}).get("Get", {}).get(index) or []
+        logger.debug("Fetched %s docs at offset %s", len(docs), offset)
         if not docs:
             break
         all_docs.extend(docs)
@@ -91,6 +103,7 @@ def _upload_docs(
     schema: dict[str, dict],
 ) -> None:
     """Upload precomputed embeddings and metadata into the pgvector store in one batch."""
+    logger.debug("Uploading %s documents to pgvector", len(docs))
     texts: list[str] = []
     embeddings: list[list[float]] = []
     metadatas: list[dict] = []
@@ -115,11 +128,12 @@ def _upload_docs(
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
+    _configure_logging()
 
     index_name = os.getenv("INDEX_NAME", os.getenv("WEAVIATE_INDEX", _INDEX2TRANSFER))
     conn_str = os.environ["PGVECTOR_URL"]
     dimension = int(os.getenv("PGVECTOR_DIMENSION", "1536"))
+    logger.debug("Using index '%s' with dimension %s", index_name, dimension)
 
     cfg = INDEX_CONFIG.get(index_name)
     if cfg is None:
@@ -129,6 +143,7 @@ def main() -> None:
         url=_WEAVIATE_URL,
         auth_client_secret=weaviate.AuthApiKey(os.environ["WEAVIATE_API_KEY"]),
     )
+    logger.debug("Connected to Weaviate at %s", _WEAVIATE_URL)
 
     store = create_collection_if_missing(
         conn_str,
@@ -136,10 +151,14 @@ def main() -> None:
         dimension,
         pre_delete_collection=_PRE_DELETE_COLLECTION,
     )
+    logger.debug("PGVector collection '%s' ready", index_name)
 
     schema_file = os.getenv("WEAVIATE_SCHEMA_FILE", r"scripts\weaviate_schema.json")
+    logger.debug("Loading schema from %s", schema_file)
     attrs, schema_cfg = _load_schema(schema_file, cfg["index_key"])
+    logger.debug("Schema loaded with %s attributes", len(attrs))
 
+    logger.debug("Fetching documents from Weaviate")
     docs = _fetch_weaviate_docs(client, index_name, cfg["index_key"], attrs)
     logger.info("Fetched %s documents from Weaviate", len(docs))
 

--- a/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
+++ b/drsearch_backend/scripts/transfer_weaviate_to_pgvector.py
@@ -1,9 +1,11 @@
-"""Transfer data from Weaviate to a pgvector collection (schema pulled live)."""
+#!/usr/bin/env python
+"""Transfer data from Weaviate to a pgvector collection (interactive index selection)."""
 
 from __future__ import annotations
 
 import logging
 import os
+import sys
 from typing import Sequence
 
 import weaviate
@@ -14,14 +16,10 @@ from scripts.create_pgvector_index import create_collection_if_missing
 
 logger = logging.getLogger(__name__)
 
-_INDEX2TRANSFER = "JACSKE_Program"
 _PRE_DELETE_COLLECTION = True
-_WEAVIATE_URL = "http://localhost:8080"  # os.environ["WEAVIATE_URL"]
+_WEAVIATE_URL = "http://localhost:8080"  # or os.getenv("WEAVIATE_URL")
 
 
-# --------------------------------------------------------------------------- #
-# Helpers
-# --------------------------------------------------------------------------- #
 def _configure_logging() -> None:
     """Configure module logging from environment."""
     level_name = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -39,9 +37,8 @@ def _extract_schema(
 ) -> tuple[list[str], dict[str, dict]]:
     """
     Pull the class schema directly from Weaviate and return:
-
-    * attrs   – list of non-text_key property names (for metadata fetching)
-    * config  – dict mapping property → minimal config details (stored in PG)
+      - attrs  : list of non-text_key property names
+      - config : dict mapping property → schema details
     """
     class_schema = client.schema.get(class_name)
     if not class_schema:
@@ -49,10 +46,9 @@ def _extract_schema(
 
     attrs: list[str] = []
     config: dict[str, dict] = {}
-
     for prop in class_schema.get("properties", []):
         name = prop.get("name")
-        if not name:  # defensive – should never be missing
+        if not name:
             continue
         if name != text_key:
             attrs.append(name)
@@ -116,7 +112,6 @@ def _upload_docs(
         texts.append(doc.get(text_key, ""))
         embeddings.append(doc["_additional"]["vector"])
         meta = {a: doc.get(a) for a in attrs}
-        # ensure rag flag is present for PGVector filtering
         meta["use4RAG"] = doc.get("use4RAG", True)
         meta["_schema"] = schema
         metadatas.append(meta)
@@ -130,31 +125,57 @@ def _upload_docs(
     )
 
 
-# --------------------------------------------------------------------------- #
-# Main
-# --------------------------------------------------------------------------- #
+def _choose_index(client: weaviate.Client) -> str:
+    """Interactively select or validate the target Weaviate class (index)."""
+    schema = client.schema.get()
+    classes = [c["class"] for c in schema.get("classes", [])]
+    if not classes:
+        raise RuntimeError("No classes found in Weaviate schema.")
+
+    # Command-line argument override
+    if len(sys.argv) > 1:
+        arg = sys.argv[1]
+        if arg in classes:
+            return arg
+        print(f"Provided index '{arg}' not found.\n")
+
+    # Interactive prompt
+    while True:
+        print("Available Weaviate classes:")
+        for i, name in enumerate(classes, start=1):
+            print(f"  {i}. {name}")
+        choice = input("Select an index by number or name: ").strip()
+        if choice.isdigit():
+            idx = int(choice)
+            if 1 <= idx <= len(classes):
+                return classes[idx - 1]
+        elif choice in classes:
+            return choice
+        print(f"Invalid selection: '{choice}'. Please try again.\n")
+
+
 def main() -> None:
     _configure_logging()
 
-    index_name = os.getenv("INDEX_NAME", os.getenv("WEAVIATE_INDEX", _INDEX2TRANSFER))
-    conn_str = os.environ["PGVECTOR_URL"]
-    dimension = int(os.getenv("PGVECTOR_DIMENSION", "1536"))
-
-    logger.info(
-        "Starting transfer for index '%s' using Weaviate at %s", index_name, _WEAVIATE_URL
+    # connect
+    client = weaviate.Client(
+        url=_WEAVIATE_URL,
+        auth_client_secret=weaviate.AuthApiKey(os.getenv("WEAVIATE_API_KEY", "")),
     )
-    logger.debug("Using index '%s' with dimension %s", index_name, dimension)
+    logger.info("Connected to Weaviate at %s", _WEAVIATE_URL)
 
+    # choose index/class
+    index_name = _choose_index(client)
+    logger.info("Using index/class '%s' for transfer", index_name)
+
+    # load index config
     cfg = INDEX_CONFIG.get(index_name)
     if cfg is None:
         raise ValueError(f"Index '{index_name}' not defined in INDEX_CONFIG")
 
-    client = weaviate.Client(
-        url=_WEAVIATE_URL,
-        auth_client_secret=weaviate.AuthApiKey(os.environ["WEAVIATE_API_KEY"]),
-    )
-    logger.debug("Connected to Weaviate at %s", _WEAVIATE_URL)
-
+    # prepare PGVector
+    conn_str = os.environ["PGVECTOR_URL"]
+    dimension = int(os.getenv("PGVECTOR_DIMENSION", "1536"))
     store = create_collection_if_missing(
         conn_str,
         index_name,
@@ -163,14 +184,13 @@ def main() -> None:
     )
     logger.debug("PGVector collection '%s' ready", index_name)
 
-    logger.debug("Fetching schema for '%s' directly from Weaviate", index_name)
+    # dynamic schema pull
     attrs, schema_cfg = _extract_schema(client, index_name, cfg["index_key"])
     logger.debug("Schema loaded with %s attributes", len(attrs))
 
-    logger.debug("Fetching documents from Weaviate")
+    # fetch & upload
     docs = _fetch_weaviate_docs(client, index_name, cfg["index_key"], attrs)
     logger.info("Fetched %s documents from Weaviate", len(docs))
-
     _upload_docs(store, docs, cfg["index_key"], attrs, schema_cfg)
     logger.info("Transfer complete: %s documents uploaded", len(docs))
 
@@ -178,6 +198,6 @@ def main() -> None:
 if __name__ == "__main__":
     try:
         main()
-    except Exception as exc:  # pragma: no cover - script entry point
+    except Exception as exc:
         logger.error("Transfer failed: %s", exc)
         raise


### PR DESCRIPTION
## Summary
- add an internal `_configure_logging` helper
- log loaded schema counts
- log fetch and upload operations
- log environment configuration in `main`

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q` *(fails: AccountName not found in connection string)*
- `yarn lint`
- `yarn format`
- `yarn test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_684c96a2e0f48325aa7c4df958b064be