### PR TITLE
Fix agentic pgvector retrieval

### DIFF
--- a/agentic_drsearch_backend/app/config.py
+++ b/agentic_drsearch_backend/app/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
     ENV: str = Field("development", env="ENV")
     # Postgres / pgvector
     PGVECTOR_URL: str = os.getenv("PGVECTOR_URL")
-    PGVECTOR_INDEX: str = os.getenv("PGVECTOR_INDEX", "default")
+    PGVECTOR_INDEX: str = os.getenv("PGVECTOR_INDEX", "SEPS")
     PG_POOL_SIZE: int = 10
     # Agent
 

--- a/agentic_drsearch_backend/app/config.py
+++ b/agentic_drsearch_backend/app/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     ENV: str = Field("development", env="ENV")
     # Postgres / pgvector
     PGVECTOR_URL: str = os.getenv("PGVECTOR_URL")
+    PGVECTOR_INDEX: str = os.getenv("PGVECTOR_INDEX", "default")
     PG_POOL_SIZE: int = 10
     # Agent
 

--- a/agentic_drsearch_backend/app/rag_agents/tools.py
+++ b/agentic_drsearch_backend/app/rag_agents/tools.py
@@ -3,20 +3,23 @@ Tool functions exposed to the OpenAI agent.
 Each tool must be decorated with @function_tool.
 """
 from typing import List, Literal
+
 from agents import function_tool
+from langchain_openai import AzureOpenAIEmbeddings
+from langchain_postgres import PGVector
+from langchain_postgres.vectorstores import DistanceStrategy
 from openai import AsyncAzureOpenAI
 
 from ..config import get_settings
-from ..database import get_conn
 from ..logging import logger
 
 settings = get_settings()
 
 openai_client = AsyncAzureOpenAI(
     api_key=settings.AZURE_OPENAI_API_KEY,
-    api_version= settings.AZURE_OPENAI_API_VERSION,
+    api_version=settings.AZURE_OPENAI_API_VERSION,
     azure_endpoint=settings.AZURE_OPENAI_ENDPOINT,
-    azure_deployment=settings.AZURE_OPENAI_EMBEDDER
+    azure_deployment=settings.AZURE_OPENAI_EMBEDDER,
 )
 
 
@@ -41,31 +44,36 @@ async def search_documents(
             <doc id="0" source="policy.pdf">...</doc>
             <doc id="1" source="manual.md">...</doc>
     """
-    # 1. Embed the query
-    embed_resp = await openai_client.embeddings.create(
-        input=[query], model=settings.AZURE_OPENAI_EMBEDDER
+    # 1. Initialise embedding model and vector store
+    embeddings = AzureOpenAIEmbeddings(
+        azure_endpoint=settings.AZURE_OPENAI_ENDPOINT,
+        api_key=settings.AZURE_OPENAI_API_KEY,
+        api_version=settings.AZURE_OPENAI_API_VERSION,
+        azure_deployment=settings.AZURE_OPENAI_EMBEDDER,
+        async_client=openai_client,
     )
-    embedding = embed_resp.data[0].embedding
-
-    # 2. Build SQL
-    op = "<->" if distance_metric == "euclidean" else "<=>"
-    sql = (
-        f"SELECT id, filename, content "
-        f"FROM documents "
-        f"ORDER BY embedding {op} %s LIMIT %s"
+    store = PGVector(
+        embeddings=embeddings,
+        connection=settings.PGVECTOR_URL,
+        collection_name=settings.PGVECTOR_INDEX,
+        async_mode=True,
+        distance_strategy=(
+            DistanceStrategy.EUCLIDEAN
+            if distance_metric == "euclidean"
+            else DistanceStrategy.COSINE
+        ),
     )
 
-    # 3. Run query
-    async with get_conn() as cur:
-        await cur.execute(sql, (embedding, top_k))
-        rows = await cur.fetchall()
+    # 2. Run similarity search via PGVector
+    docs = await store.asimilarity_search(query=query, k=top_k)
 
-    # 4. Format result
+    # 3. Format result
     snippets: List[str] = []
-    for idx, (_, filename, content) in enumerate(rows):
-        snippet = content[:1000].replace("\n", " ")
+    for idx, doc in enumerate(docs):
+        filename = doc.metadata.get("filename", "unknown")
+        snippet = doc.page_content[:1000].replace("\n", " ")
         snippets.append(f'<doc id="{idx}" source="{filename}">{snippet}</doc>')
 
     joined = "\n".join(snippets)
-    logger.debug("search_documents returned %d docs", len(rows))
+    logger.debug("search_documents returned %d docs", len(docs))
     return joined

--- a/agentic_drsearch_backend/pyproject.toml
+++ b/agentic_drsearch_backend/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
   "psycopg-pool (>=3.2.6,<4.0.0)",
   "openai-agents (>=0.0.17,<0.0.18)",
   "truststore (>=0.10.1,<0.11.0)",
-  "langchain-postgres (>=0.0.14,<0.0.15)"
+  "langchain-postgres (>=0.0.14,<0.0.15)",
+  "langchain-openai>=0.1.7,<0.2.0"
 ]
 
 [project.optional-dependencies]

--- a/agentic_drsearch_backend/tests/test_api.py
+++ b/agentic_drsearch_backend/tests/test_api.py
@@ -1,5 +1,16 @@
+import os
 import httpx
 import pytest
+
+# Minimal env vars so Settings can load during tests
+os.environ.setdefault("PGVECTOR_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("PGVECTOR_INDEX", "test")
+os.environ.setdefault("AZURE_OPENAI_LLM_DEPLOYMENT", "gpt4")
+os.environ.setdefault("AZURE_OPENAI_API_KEY", "dummy")
+os.environ.setdefault("AZURE_OPENAI_API_VERSION", "2024-10-21")
+os.environ.setdefault("AZURE_OPENAI_ENDPOINT", "https://example.com")
+os.environ.setdefault("AZURE_OPENAI_EMBEDDER", "text-embedding-ada-002")
+
 from app.main import app
 from app.api.v1 import routes
 from app.rag_agents import agent


### PR DESCRIPTION
## Summary
- integrate PGVector retriever from `langchain-postgres`
- add PGVECTOR_INDEX env configuration
- provide async PGVector search tool
- update tests to set env vars
- add `langchain-openai` dependency

## Testing
- `poetry run pytest -q`
- `poetry run pytest --cov=app --cov-report=term-missing -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685056ac41c48325b9734e35620191b2