### PR TITLE
Use PostgreSQL for file mappings

### DIFF
--- a/drsearch_backend/app/chain/mapping.py
+++ b/drsearch_backend/app/chain/mapping.py
@@ -12,7 +12,7 @@ from typing import Dict, Optional
 import psycopg2
 from psycopg2 import sql
 
-from app.core.chain_config import _MAPPING_DIR
+
 
 logger = logging.getLogger(__name__)
 

--- a/drsearch_backend/app/chain/mapping.py
+++ b/drsearch_backend/app/chain/mapping.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import csv
 import logging
+import os
 from functools import cached_property
 from pathlib import Path
 from typing import Dict, Optional
+
+import psycopg2
+from psycopg2 import sql
 
 from app.core.chain_config import _MAPPING_DIR
 
@@ -14,25 +18,63 @@ logger = logging.getLogger(__name__)
 
 
 class PartNumberMapping:
-    """Lazily loads part-number → UNC path CSV lookup tables."""
+    """Lazily loads part-number → file-path lookup tables from PostgreSQL."""
 
-    def __init__(self, csv_filename: Optional[str]):
-        self._csv_filename = csv_filename
+    def __init__(self, table_name: Optional[str]):
+        self._table_name = table_name
 
     @cached_property
     def data(self) -> Dict[str, str] | None:
-        """Return the in-memory mapping or None when no file configured."""
-        if not self._csv_filename:
+        """Return the in-memory mapping or ``None`` when unavailable."""
+        if not self._table_name:
             return None
 
-        csv_path = _MAPPING_DIR / self._csv_filename
-        if not csv_path.exists():
-            logger.warning("Mapping CSV '%s' not found", csv_path)
+        conn_str = os.getenv("PGVECTOR_URL")
+        if not conn_str:
+            logger.warning("PGVECTOR_URL environment variable not set")
             return None
 
-        mapping: Dict[str, str] = {}
-        with csv_path.open(newline="", encoding="utf-8") as handle:
-            for row in csv.DictReader(handle):
-                mapping[row["file_name"]] = row["Downloaded File"]
+        try:
+            with psycopg2.connect(conn_str) as conn, conn.cursor() as cur:
+                query = sql.SQL(
+                    "SELECT file_name, downloaded_file FROM {}"
+                ).format(sql.Identifier(self._table_name))
+                cur.execute(query)
+                rows = cur.fetchall()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to load mapping table '%s': %s", self._table_name, exc)
+            return None
+
+        mapping: Dict[str, str] = {file: path for file, path in rows}
         logger.debug("Loaded %d part-number mappings", len(mapping))
         return mapping
+
+
+def create_mapping_table_from_csv(
+    csv_path: Path, conn_str: str, table_name: str
+) -> None:
+    """Create or update a PostgreSQL mapping table from ``csv_path``."""
+    with psycopg2.connect(conn_str) as conn, conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                "CREATE TABLE IF NOT EXISTS {} (" "file_name TEXT PRIMARY KEY, "
+                "downloaded_file TEXT)"
+            ).format(sql.Identifier(table_name))
+        )
+
+        with csv_path.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            rows = [
+                (row["file_name"], row["Downloaded File"]) for row in reader
+            ]
+
+        cur.executemany(
+            sql.SQL(
+                "INSERT INTO {} (file_name, downloaded_file) "
+                "VALUES (%s, %s) "
+                "ON CONFLICT (file_name) DO UPDATE "
+                "SET downloaded_file = EXCLUDED.downloaded_file"
+            ).format(sql.Identifier(table_name)),
+            rows,
+        )
+        conn.commit()

--- a/drsearch_backend/scripts/create_mapping_table.py
+++ b/drsearch_backend/scripts/create_mapping_table.py
@@ -1,0 +1,39 @@
+"""Create or update a part-number mapping table from a CSV file."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+from app.chain.mapping import create_mapping_table_from_csv
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    conn_str = os.environ.get("PGVECTOR_URL")
+    if not conn_str:
+        raise EnvironmentError("PGVECTOR_URL must be set")
+
+    parser = argparse.ArgumentParser(
+        description="Load CSV data into a PostgreSQL mapping table"
+    )
+    parser.add_argument("csv", help="Path to CSV file with mapping entries")
+    parser.add_argument("table", help="Target PostgreSQL table name")
+    args = parser.parse_args()
+
+    csv_path = Path(args.csv)
+    create_mapping_table_from_csv(csv_path, conn_str, args.table)
+    logger.info("Mapping table '%s' updated from %s", args.table, csv_path)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # pragma: no cover - script entry point
+        logger.error("Failed to create mapping table: %s", exc)
+        raise

--- a/drsearch_backend/scripts/create_mapping_table.py
+++ b/drsearch_backend/scripts/create_mapping_table.py
@@ -7,6 +7,9 @@ import logging
 import os
 from pathlib import Path
 
+import psycopg2
+from psycopg2 import sql
+
 from app.chain.mapping import create_mapping_table_from_csv
 
 logger = logging.getLogger(__name__)
@@ -27,8 +30,16 @@ def main() -> None:
     args = parser.parse_args()
 
     csv_path = Path(args.csv)
+
+    # Drop the table so the load is always deterministic
+    with psycopg2.connect(conn_str) as conn, conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("DROP TABLE IF EXISTS {}").format(sql.Identifier(args.table))
+        )
+        conn.commit()
+
     create_mapping_table_from_csv(csv_path, conn_str, args.table)
-    logger.info("Mapping table '%s' updated from %s", args.table, csv_path)
+    logger.info("Mapping table '%s' recreated from %s", args.table, csv_path)
 
 
 if __name__ == "__main__":

--- a/drsearch_backend/tests/test_app.py
+++ b/drsearch_backend/tests/test_app.py
@@ -5,9 +5,12 @@
 from __future__ import annotations
 
 from typing import Any
+import os
 
 import pytest
 from fastapi.testclient import TestClient
+
+os.environ["AZURE_STORAGE_CONNECTION_STRING"] = ""
 
 from app import create_app
 

--- a/drsearch_backend/tests/test_chat_engine.py
+++ b/drsearch_backend/tests/test_chat_engine.py
@@ -174,12 +174,33 @@ def test_context_map_with_retriever(monkeypatch):
     assert "answer" in result
 
 
-def test_modify_docs_enriches_path(monkeypatch, tmp_path):
-    csv_content = "file_name,Downloaded File\nabc.pdf,\\\\server\\abc.pdf\n"
-    mapping_file = tmp_path / "JACSKE_PROD_DEPLOY.csv"
-    mapping_file.write_text(csv_content, encoding="utf-8")
+def test_modify_docs_enriches_path(monkeypatch):
+    rows = [("abc.pdf", "\\\\server\\abc.pdf")]
 
-    monkeypatch.setattr("app.chain.mapping._MAPPING_DIR", tmp_path)
+    class DummyCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, _q):
+            pass
+
+        def fetchall(self):
+            return rows
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def cursor(self):
+            return DummyCursor()
+
+    monkeypatch.setattr("app.chain.mapping.psycopg2.connect", lambda *_a, **_k: DummyConn())
 
     # Ensure retriever chain uses a predictable in-memory retriever instead of
     # the real Weaviate vector-store, which is outside the scope of unit tests.

--- a/drsearch_backend/tests/test_document_formatter.py
+++ b/drsearch_backend/tests/test_document_formatter.py
@@ -7,32 +7,45 @@ from app.chain.formatter import DocumentFormatter
 from app.chain.mapping import PartNumberMapping
 
 
-def test_formatter_deduplicates_and_adds_mapping(tmp_path, monkeypatch):
-    # 1) create a dummy CSV mapping file
-    csv_content = "file_name,Downloaded File\nabc.pdf,\\\\share\\abc.pdf\n"
-    csv_file = tmp_path / "map.csv"
-    csv_file.write_text(csv_content, encoding="utf-8")
+def test_formatter_deduplicates_and_adds_mapping(monkeypatch):
+    rows = [("abc.pdf", "\\\\share\\abc.pdf")]
 
-    # <-- This is the fix: ensure mapping reads from the temp directory
-    monkeypatch.setattr("app.chain.mapping._MAPPING_DIR", tmp_path)
+    class DummyCursor:
+        def __enter__(self):
+            return self
 
-    # mapping = PartNumberMapping(csv_file.name)          # filename only
-    monkeypatch.setattr("app.chain.mapping._MAPPING_DIR", tmp_path)
-    mapping = PartNumberMapping(csv_file.name.split("\\")[-1])
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, _q):
+            pass
+
+        def fetchall(self):
+            return rows
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def cursor(self):
+            return DummyCursor()
+
+    monkeypatch.setattr("app.chain.mapping.psycopg2.connect", lambda *_a, **_k: DummyConn())
+
+    mapping = PartNumberMapping("tbl")
     formatter = DocumentFormatter(mapping)
 
     docs = [
         Document(page_content="same-text", metadata={"filename": "abc.pdf"}),
-        Document(page_content="same-text", metadata={"filename": "abc.pdf"}),  # dup
+        Document(page_content="same-text", metadata={"filename": "abc.pdf"}),
     ]
 
     out = formatter(docs)
 
-    # deduplicated → only one <doc …>
     assert out.count("<doc") == 1
-    # # UNC path injected
-    # assert "\\\\share\\abc.pdf" in out
-    # UNC path injected into metadata, not the xml string
     assert formatter._mapping["abc.pdf"] == "\\\\share\\abc.pdf"
 
 

--- a/drsearch_backend/tests/test_part_number_mapping.py
+++ b/drsearch_backend/tests/test_part_number_mapping.py
@@ -1,20 +1,88 @@
 from app.chain.mapping import PartNumberMapping
 
 
-def test_part_number_mapping_reads_csv(tmp_path, monkeypatch):
-    csv_data = "file_name,Downloaded File\nx.pdf,\\\\srv\\x.pdf\n"
-    f = tmp_path / "m.csv"
-    f.write_text(csv_data)
+def test_create_mapping_table_from_csv(monkeypatch, tmp_path):
+    from app.chain import mapping as mapping_mod
 
-    # m = PartNumberMapping(f.name)
-    monkeypatch.setattr("app.chain.mapping._MAPPING_DIR", tmp_path)
-    m = PartNumberMapping(f.name.split("\\")[-1])   # basename only
+    csv_content = "file_name,Downloaded File\nabc.pdf,\\\\share\\abc.pdf\n"
+    csv_file = tmp_path / "m.csv"
+    csv_file.write_text(csv_content, encoding="utf-8")
+
+    executed: list[tuple[str, tuple | list]] = []
+
+    class DummyCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, q, params=None):
+            executed.append((str(q), params))
+
+        def executemany(self, q, params_seq):
+            executed.append((str(q), list(params_seq)))
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def cursor(self):
+            return DummyCursor()
+
+        def commit(self):
+            executed.append(("commit", ()))
+
+    monkeypatch.setattr(mapping_mod.psycopg2, "connect", lambda *_a, **_k: DummyConn())
+
+    mapping_mod.create_mapping_table_from_csv(csv_file, "conn", "tbl")
+
+    assert any("CREATE TABLE" in e[0] for e in executed)
+    assert any("INSERT INTO" in e[0] for e in executed)
+
+
+def test_part_number_mapping_reads_table(monkeypatch):
+    rows = [("x.pdf", "\\\\srv\\x.pdf")]
+
+    class DummyCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, _q):
+            pass
+
+        def fetchall(self):
+            return rows
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def cursor(self):
+            return DummyCursor()
+
+    monkeypatch.setattr("app.chain.mapping.psycopg2.connect", lambda *_a, **_k: DummyConn())
+
+    m = PartNumberMapping("dummy_table")
     assert m.data == {"x.pdf": "\\\\srv\\x.pdf"}
 
 
-def test_part_number_mapping_missing_file(caplog):
-    m = PartNumberMapping("does-not-exist.csv")
+def test_part_number_mapping_missing_table(caplog, monkeypatch):
+    def _raise(*_a, **_k):
+        raise Exception("missing")
+
+    monkeypatch.setattr("app.chain.mapping.psycopg2.connect", _raise)
+
+    m = PartNumberMapping("missing")
     assert m.data is None
-    # warning logged once
-    warnings = [r for r in caplog.messages if "not found" in r]
+    warnings = [r for r in caplog.messages if "Failed to load" in r]
     assert warnings


### PR DESCRIPTION
## Summary
- load part number mappings from PostgreSQL
- add helper to create mapping table from CSV
- update ChatEngine and formatter tests for DB mappings
- adjust mapping unit tests

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68507b9a14188325867ea5a672c0c6f7