### PR TITLE
Add fake pgvector data loader and backend test script

### DIFF
--- a/codex_environment_setup_scripts/fake_document_chunks.json
+++ b/codex_environment_setup_scripts/fake_document_chunks.json
@@ -1,0 +1,12 @@
+[
+  {"document": "Fake content 1", "cmetadata": {"file_path": "/docs/file1.pdf", "filename": "file1.pdf", "url": "http://example.com/file1", "text_as_html": "<p>Fake content 1</p>"}},
+  {"document": "Fake content 2", "cmetadata": {"file_path": "/docs/file2.pdf", "filename": "file2.pdf", "url": "http://example.com/file2", "text_as_html": "<p>Fake content 2</p>"}},
+  {"document": "Fake content 3", "cmetadata": {"file_path": "/docs/file3.pdf", "filename": "file3.pdf", "url": "http://example.com/file3", "text_as_html": "<p>Fake content 3</p>"}},
+  {"document": "Fake content 4", "cmetadata": {"file_path": "/docs/file4.pdf", "filename": "file4.pdf", "url": "http://example.com/file4", "text_as_html": "<p>Fake content 4</p>"}},
+  {"document": "Fake content 5", "cmetadata": {"file_path": "/docs/file5.pdf", "filename": "file5.pdf", "url": "http://example.com/file5", "text_as_html": "<p>Fake content 5</p>"}},
+  {"document": "Fake content 6", "cmetadata": {"file_path": "/docs/file6.pdf", "filename": "file6.pdf", "url": "http://example.com/file6", "text_as_html": "<p>Fake content 6</p>"}},
+  {"document": "Fake content 7", "cmetadata": {"file_path": "/docs/file7.pdf", "filename": "file7.pdf", "url": "http://example.com/file7", "text_as_html": "<p>Fake content 7</p>"}},
+  {"document": "Fake content 8", "cmetadata": {"file_path": "/docs/file8.pdf", "filename": "file8.pdf", "url": "http://example.com/file8", "text_as_html": "<p>Fake content 8</p>"}},
+  {"document": "Fake content 9", "cmetadata": {"file_path": "/docs/file9.pdf", "filename": "file9.pdf", "url": "http://example.com/file9", "text_as_html": "<p>Fake content 9</p>"}},
+  {"document": "Fake content 10", "cmetadata": {"file_path": "/docs/file10.pdf", "filename": "file10.pdf", "url": "http://example.com/file10", "text_as_html": "<p>Fake content 10</p>"}}
+]

--- a/codex_environment_setup_scripts/load_pgvector_data.sh
+++ b/codex_environment_setup_scripts/load_pgvector_data.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+DB_USER="username"
+DB_PASS="password"
+DB_HOST="localhost"
+DB_NAME="pgvector_db"
+DATA_FILE="$(dirname "$0")/fake_document_chunks.json"
+
+python3 - <<'PY'
+import json, os, uuid, random
+import psycopg2
+from pgvector.psycopg2 import register_vector
+
+DB_USER=os.environ.get('DB_USER', 'username')
+DB_PASS=os.environ.get('DB_PASS', 'password')
+DB_HOST=os.environ.get('DB_HOST', 'localhost')
+DB_NAME=os.environ.get('DB_NAME', 'pgvector_db')
+DATA_FILE=os.environ['DATA_FILE']
+
+conn = psycopg2.connect(dbname=DB_NAME, user=DB_USER, password=DB_PASS, host=DB_HOST)
+register_vector(conn)
+cur = conn.cursor()
+collection_uuid = str(uuid.uuid4())
+cur.execute(
+    "INSERT INTO public.langchain_pg_collection (name, cmetadata, uuid) VALUES (%s, %s, %s)",
+    ('JACSKE_Program', '{}', collection_uuid),
+)
+with open(DATA_FILE, 'r', encoding='utf-8') as f:
+    docs = json.load(f)
+for idx, item in enumerate(docs, 1):
+    emb = [random.random() for _ in range(1536)]
+    cur.execute(
+        "INSERT INTO public.langchain_pg_embedding (collection_id, embedding, document, cmetadata, custom_id, uuid) VALUES (%s, %s, %s, %s, %s, %s)",
+        (collection_uuid, emb, item['document'], json.dumps(item['cmetadata']), f'doc{idx}', str(uuid.uuid4())),
+    )
+conn.commit()
+cur.close()
+conn.close()
+PY
+
+echo "Loaded fake data into collection $collection_uuid"

--- a/codex_environment_setup_scripts/run_backend_tests.sh
+++ b/codex_environment_setup_scripts/run_backend_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.." # project root
+
+export PGVECTOR_URL="postgresql://username:password@localhost:5432/pgvector_db"
+export VECTOR_BACKEND="pgvector"
+export RAG_ON="True"
+export LLM_SERVICE="fake"
+export AUTH_ENABLED="False"
+
+poetry run uvicorn app:app --host 0.0.0.0 --port 8011 &
+PID=$!
+sleep 5
+
+status=$(curl -s -o /tmp/index.json -w "%{http_code}" http://localhost:8011/index-options)
+if [ "$status" != "200" ]; then echo "index-options failed"; kill $PID; exit 1; fi
+
+chat_status=$(curl -s -o /tmp/chat.log -w "%{http_code}" -H "Content-Type: application/json" -d '{"input":{"question":"hello"}}' http://localhost:8011/chat/stream_log)
+if [ "$chat_status" != "200" ]; then echo "chat failed"; kill $PID; exit 1; fi
+
+fb_status=$(curl -s -o /tmp/fb.json -w "%{http_code}" -H "Content-Type: application/json" -d '{"run_id":"11111111-1111-1111-1111-111111111111","key":"user_score","score":1}' http://localhost:8011/feedback)
+if [ "$fb_status" != "200" ]; then echo "feedback failed"; kill $PID; exit 1; fi
+
+kill $PID
+sleep 2
+
+echo "All backend endpoint checks passed"

--- a/drsearch_backend/app/chain/engine.py
+++ b/drsearch_backend/app/chain/engine.py
@@ -69,15 +69,22 @@ class ChatEngine:
 
     @staticmethod
     def _init_llm() -> BaseLanguageModel:
-        """Instantiate Azure Chat completion model (singleton per process)."""
+        """Instantiate a chat model based on ``LLM_SERVICE`` env-var."""
+        service = os.getenv("LLM_SERVICE", "azure").lower()
         try:
+            if service == "fake":
+                from langchain.llms.fake import FakeListLLM
+
+                logger.info("Using FakeListLLM model")
+                return FakeListLLM(responses=["fake response"])
+
             logger.info("Creating AzureChatOpenAI model")
             return AzureChatOpenAI(
                 azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
                 api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-                api_version=os.environ["AZURE_OPENAI_API_VERSION"],
+                api_version=os.environ.get("AZURE_OPENAI_API_VERSION"),
                 temperature=0.0,
-                model=os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+                model=os.environ.get("AZURE_OPENAI_DEPLOYMENT_NAME"),
                 streaming=True,
             )
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- provide fake document chunks for PGVector data loading
- script to load fake documents into pgvector
- script to run backend smoke tests
- use FakeListLLM when LLM_SERVICE=fake

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `poetry run pylint app`

------
https://chatgpt.com/codex/tasks/task_e_6851e219b9948325a6415df4c02e1320