### PR TITLE
Fix backend init default

### DIFF
--- a/drsearch_backend/README.md
+++ b/drsearch_backend/README.md
@@ -1,8 +1,17 @@
 # DRSearch
+
 A RAG Chatbot
 
+## Running the Backend Locally
 
+The FastAPI application is fully initialised by default. You can start it with:
 
+```bash
+poetry run uvicorn app:app --host 0.0.0.0 --port 8011
+```
+
+If you need to disable automatic initialisation (for example during tests), set
+the environment variable `INIT_APP=false` before running Uvicorn.
 
 ## To run test, use this command:
 ### This will:

--- a/drsearch_backend/app/__init__.py
+++ b/drsearch_backend/app/__init__.py
@@ -49,10 +49,10 @@ def create_app() -> FastAPI:
     return app
 
 
-# Application instance for `uvicorn app:app` style invocation. Set the
-# environment variable ``INIT_APP=false`` during tests to defer creation
-# until explicitly requested.
-if os.getenv("INIT_APP", "false").lower() == "true":
+# Application instance for `uvicorn app:app` style invocation.
+# By default the application is fully initialised.  Tests can set
+# ``INIT_APP=false`` to defer creation until explicitly requested.
+if os.getenv("INIT_APP", "true").lower() == "true":
     app = create_app()
 else:
     app = FastAPI()


### PR DESCRIPTION
## Summary
- initialize FastAPI app by default
- document backend startup instructions

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685338ab4f7c8325a6782e23d98ce098