### PR TITLE
Fix openapi generation and retriever callbacks

### DIFF
--- a/drsearch_backend/app/__init__.py
+++ b/drsearch_backend/app/__init__.py
@@ -42,6 +42,34 @@ def create_app() -> FastAPI:
     # -------------------- routers --------------------
     app.include_router(build_router(settings=settings))
 
+    # -------------------- openapi fix --------------------
+    from fastapi.openapi.utils import get_openapi
+    from pydantic.errors import PydanticUserError
+    from pydantic import BaseModel
+    import langserve.validation as lv
+
+    def custom_openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+        try:
+            app.openapi_schema = get_openapi(
+                title=app.title,
+                version=app.version,
+                routes=app.routes,
+            )
+        except PydanticUserError:
+            for obj in lv.__dict__.values():
+                if isinstance(obj, type) and issubclass(obj, BaseModel):
+                    obj.model_rebuild(force=True)
+            app.openapi_schema = get_openapi(
+                title=app.title,
+                version=app.version,
+                routes=app.routes,
+            )
+        return app.openapi_schema
+
+    app.openapi = custom_openapi
+
     @app.on_event("startup")
     async def warm_up() -> None:
         await warm_up_indexes()

--- a/drsearch_backend/app/vectorstores/pgvector_store.py
+++ b/drsearch_backend/app/vectorstores/pgvector_store.py
@@ -67,7 +67,7 @@ class PgVectorStore(VectorStore):
                 return _strip(docs)
 
             async def _aget_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
-                docs = await base.aget_relevant_documents(query, callbacks=run_manager)
+                docs = await base.ainvoke(query, config={"callbacks": run_manager})
                 return _strip(docs)
 
         return _FilteredRetriever()


### PR DESCRIPTION
## Summary
- patch openapi generation in `create_app` to rebuild models for Pydantic 2.11
- update `PgVectorStore` retriever to use `ainvoke` with new callback config
- ensure tests pass

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68542e84bba48325a4efa66cd26d5876