### PR TITLE
Fix warmup retrieval and OpenAPI generation

### DIFF
--- a/drsearch_backend/app/__init__.py
+++ b/drsearch_backend/app/__init__.py
@@ -60,7 +60,11 @@ def create_app() -> FastAPI:
         except PydanticUserError:
             for obj in lv.__dict__.values():
                 if isinstance(obj, type) and issubclass(obj, BaseModel):
-                    obj.model_rebuild(force=True)
+                    try:
+                        obj.model_rebuild(force=True)
+                    except AttributeError:
+                        # Some models may not expose rebuild in newer pydantic versions
+                        pass
             app.openapi_schema = get_openapi(
                 title=app.title,
                 version=app.version,

--- a/drsearch_backend/app/__init__.py
+++ b/drsearch_backend/app/__init__.py
@@ -3,7 +3,10 @@
 """Application package initialisation."""
 
 import os
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .core.config import Settings, get_settings
 from .core.logging import configure_logging
@@ -11,7 +14,6 @@ from .core.logging_middleware import LoggingMiddleware
 from .auth.middleware import AuthMiddleware
 from .api.v1.routes import build_router
 from .warmup import warm_up_indexes
-from fastapi.middleware.cors import CORSMiddleware
 
 
 def create_app() -> FastAPI:
@@ -24,7 +26,13 @@ def create_app() -> FastAPI:
     settings: Settings = get_settings()
     configure_logging()
 
-    app = FastAPI(debug=settings.debug)
+    # -------------------- lifespan --------------------
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        await warm_up_indexes()
+        yield
+
+    app = FastAPI(debug=settings.debug, lifespan=lifespan)
 
     # ------------------- ADD CORS -------------------
     app.add_middleware(
@@ -63,7 +71,6 @@ def create_app() -> FastAPI:
                     try:
                         obj.model_rebuild(force=True)
                     except AttributeError:
-                        # Some models may not expose rebuild in newer pydantic versions
                         pass
             app.openapi_schema = get_openapi(
                 title=app.title,
@@ -73,10 +80,6 @@ def create_app() -> FastAPI:
         return app.openapi_schema
 
     app.openapi = custom_openapi
-
-    @app.on_event("startup")
-    async def warm_up() -> None:
-        await warm_up_indexes()
 
     return app
 

--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -64,6 +64,7 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
         path="/chat",
         input_type=ChatRequest,
         config_keys=["metadata"],
+        playground_type="chat",
     )
 
     # ---- /index-options

--- a/drsearch_backend/app/vectorstores/pgvector_store.py
+++ b/drsearch_backend/app/vectorstores/pgvector_store.py
@@ -63,11 +63,21 @@ class PgVectorStore(VectorStore):
 
         class _FilteredRetriever(BaseRetriever):
             def _get_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
-                docs = base.get_relevant_documents(query, callbacks=run_manager)
+                callbacks = (
+                    list(run_manager.handlers)
+                    if run_manager and hasattr(run_manager, "handlers")
+                    else None
+                )
+                docs = base.get_relevant_documents(query, callbacks=callbacks)
                 return _strip(docs)
 
             async def _aget_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
-                docs = await base.ainvoke(query, config={"callbacks": run_manager})
+                callbacks = (
+                    list(run_manager.handlers)
+                    if run_manager and hasattr(run_manager, "handlers")
+                    else None
+                )
+                docs = await base.ainvoke(query, config={"callbacks": callbacks})
                 return _strip(docs)
 
         return _FilteredRetriever()


### PR DESCRIPTION
## Summary
- adjust callback handling in pgvector store retriever to support latest langchain
- guard openapi model rebuild for compatibility with newer Pydantic

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `LOG_OUTPUT_MODE=local AZURE_STORAGE_CONNECTION_STRING="dummy" poetry run uvicorn app:app --host 0.0.0.0 --port 8011` *(started then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_685434ce0d1c8325831a35a563bacfe5