### PR TITLE
Add agent-chat endpoint

### DIFF
--- a/drsearch_backend/README.md
+++ b/drsearch_backend/README.md
@@ -6,6 +6,7 @@ A RAG Chatbot
 
 The FastAPI application is fully initialised by default. You can start it with:
 
+The API exposes two chat endpoints: `/chat` for standard RAG and `/agent-chat` for an agent-driven workflow.
 ```bash
 poetry run uvicorn app:app --host 0.0.0.0 --port 8011
 ```

--- a/drsearch_backend/app/agent/rag_agent.py
+++ b/drsearch_backend/app/agent/rag_agent.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, Tuple
+
+from langchain.agents import AgentExecutor
+from langchain.agents.format_scratchpad.openai_tools import (
+    format_to_openai_tool_messages,
+)
+from langchain.agents.output_parsers.openai_tools import (
+    OpenAIToolsAgentOutputParser,
+)
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.runnables import Runnable, RunnableLambda
+from langchain_core.tools import tool
+from langchain_core.utils.function_calling import format_tool_to_openai_tool
+from langchain_openai import AzureChatOpenAI
+
+from app import System_Prompts
+from app.chain.formatter import DocumentFormatter
+from app.chain.history import HistorySerializer
+from app.chain.mapping import PartNumberMapping
+from app.chain.retriever import RetrieverFactory
+from app.core.chain_config import _DEFAULT_INDEX, _NUMBER_OF_DOCS_RETRIEVED, RAG_ON
+from app.index_config import INDEX_CONFIG
+
+_agent_cache: Dict[Tuple[str, int], Runnable] = {}
+
+
+def _agent_for(index_name: str, num_docs: int) -> Runnable:
+    key = (index_name, num_docs)
+    if key not in _agent_cache:
+        from app.core import chain_config
+
+        chain_config._NUMBER_OF_DOCS_RETRIEVED = num_docs
+        cfg = INDEX_CONFIG.get(index_name)
+        if cfg is None:
+            system_prompt = System_Prompts.RESPONSE_TEMPLATE_CHATBOT
+            mapping_name = None
+        else:
+            system_prompt = cfg["response_template"]
+            mapping_name = cfg.get("PN_TO_FILE_MAPPING")
+
+        llm = AzureChatOpenAI(
+            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+            api_version=os.environ["AZURE_OPENAI_API_VERSION"],
+            temperature=0.0,
+            model=os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"],
+            streaming=True,
+        )
+
+        tools = []
+        if RAG_ON and cfg is not None:
+            retriever = RetrieverFactory.build(index_name)
+            formatter = DocumentFormatter(PartNumberMapping(mapping_name))
+
+            @tool
+            def search_docs(query: str) -> str:
+                """Search relevant documents"""
+                docs = retriever.get_relevant_documents(query)
+                return formatter(docs)
+
+            tools.append(search_docs)
+
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", system_prompt),
+                MessagesPlaceholder(variable_name="chat_history"),
+                ("user", "{input}"),
+                MessagesPlaceholder(variable_name="agent_scratchpad"),
+            ]
+        )
+
+        llm_with_tools = llm.bind(tools=[format_tool_to_openai_tool(t) for t in tools])
+
+        agent = (
+            {
+                "input": lambda x: x["input"],
+                "agent_scratchpad": lambda x: format_to_openai_tool_messages(
+                    x.get("intermediate_steps", [])
+                ),
+                "chat_history": lambda x: x["chat_history"],
+            }
+            | prompt
+            | llm_with_tools
+            | OpenAIToolsAgentOutputParser()
+        )
+
+        executor = AgentExecutor(agent=agent, tools=tools)
+        history = HistorySerializer()
+        runnable = (
+            RunnableLambda(
+                lambda d: {
+                    "input": d["question"],
+                    "chat_history": history(d),
+                }
+            )
+            | executor
+        )
+        _agent_cache[key] = runnable
+    return _agent_cache[key]
+
+
+def get_agent_executor(
+    index_name: str | None = None, num_docs: int = _NUMBER_OF_DOCS_RETRIEVED
+) -> Runnable:
+    return _agent_for(index_name or _DEFAULT_INDEX, num_docs)
+
+
+agent_chain: Runnable = RunnableLambda(
+    lambda inputs: get_agent_executor(
+        inputs.get("index_name", _DEFAULT_INDEX),
+        inputs.get("num_docs_retrieved", _NUMBER_OF_DOCS_RETRIEVED),
+    )
+)

--- a/drsearch_backend/app/api/v1/agent_routes.py
+++ b/drsearch_backend/app/api/v1/agent_routes.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from langserve import add_routes
+
+from app.agent.rag_agent import agent_chain
+from app.models import ChatRequest
+
+
+def build_agent_router() -> APIRouter:
+    router = APIRouter()
+    add_routes(
+        router,
+        agent_chain,
+        path="/agent-chat",
+        input_type=ChatRequest,
+        config_keys=["metadata"],
+        playground_type="chat",
+    )
+    return router

--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Response
 from fastapi.responses import FileResponse
 from langserve import add_routes
 
+from .agent_routes import build_agent_router
 from ...core.config import Settings, get_settings
 from ...auth.middleware import AuthMiddleware  # noqa: F401 – imported for side-effects
 from app.auth import jwt  # triggers cache warming on app-start
@@ -66,6 +67,8 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
         config_keys=["metadata"],
         playground_type="chat",
     )
+
+    router.include_router(build_agent_router())
 
     # ---- /index-options
     @router.get("/index-options", response_model=IndexOptionsResponse)

--- a/drsearch_backend/app/models/__init__.py
+++ b/drsearch_backend/app/models/__init__.py
@@ -2,12 +2,14 @@
 
 from .chat import ChatRequest
 from .feedback import Feedback, FeedbackUpdate
+from .agent import AgentOutput
 from .trace import TraceRequest
 from .shared import StandardResponse, IndexOption, IndexOptionsResponse
 
 __all__ = [
     "ChatRequest",
     "Feedback",
+    "AgentOutput",
     "FeedbackUpdate",
     "TraceRequest",
     "StandardResponse",

--- a/drsearch_backend/app/models/agent.py
+++ b/drsearch_backend/app/models/agent.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class AgentOutput(BaseModel):
+    """Generic wrapper for agent responses."""
+
+    output: Any

--- a/drsearch_backend/app/warmup.py
+++ b/drsearch_backend/app/warmup.py
@@ -6,6 +6,8 @@ import logging
 from app.index_options import INDEX_OPTIONS
 from app.chain.api import get_answer_chain
 
+from app.agent.rag_agent import get_agent_executor
+
 logger = logging.getLogger(__name__)
 
 # Track whether each index has been successfully warmed up
@@ -16,6 +18,8 @@ async def warm_up_indexes() -> None:
     """Initialise all indexes so first user request is fast."""
     for index_name in INDEX_STATUS.keys():
         try:
+            agent = get_agent_executor(index_name)
+            await agent.ainvoke({"question": "warmup", "chat_history": []})
             engine = get_answer_chain(index_name)
             await engine.ainvoke({"question": "warmup", "chat_history": []})
             INDEX_STATUS[index_name] = True

--- a/drsearch_backend/tests/test_agent_api.py
+++ b/drsearch_backend/tests/test_agent_api.py
@@ -1,0 +1,35 @@
+def test__agent_for_creates_and_caches(monkeypatch):
+    from app.agent import rag_agent as api
+
+    api._agent_cache.clear()
+    monkeypatch.setattr(api, "RAG_ON", False)
+
+    class DummyLLM:
+        def __init__(self, *_, **__):
+            pass
+
+        def bind(self, **kwargs):
+            return lambda *_a, **_k: None
+
+    class DummyExec:
+        def __init__(self, *_, **__):
+            pass
+
+        def __call__(self, *_, **__):
+            return None
+
+    monkeypatch.setattr(api, "AzureChatOpenAI", DummyLLM)
+    monkeypatch.setattr(api, "AgentExecutor", DummyExec)
+
+    first = api.get_agent_executor("IDX", 3)
+    second = api.get_agent_executor("IDX", 3)
+    assert first is second
+
+
+def test_get_agent_executor(monkeypatch):
+    from app.agent import rag_agent as api
+
+    dummy = object()
+    monkeypatch.setattr(api, "_agent_for", lambda *_, **__: dummy)
+    assert api.get_agent_executor(None, 2) is dummy
+    assert api.get_agent_executor("ALT", 2) is dummy

--- a/drsearch_backend/tests/test_agent_routes.py
+++ b/drsearch_backend/tests/test_agent_routes.py
@@ -1,0 +1,6 @@
+from fastapi.testclient import TestClient
+
+
+def test_agent_chat_requires_body(fastapi_client: TestClient):
+    response = fastapi_client.post("/agent-chat/invoke")
+    assert response.status_code == 422

--- a/drsearch_backend/tests/test_warmup.py
+++ b/drsearch_backend/tests/test_warmup.py
@@ -17,6 +17,7 @@ def test_warm_up_success(monkeypatch):
             return "ok"
 
     monkeypatch.setattr(warmup, "get_answer_chain", lambda name: Dummy())
+    monkeypatch.setattr(warmup, "get_agent_executor", lambda name: Dummy())
 
     asyncio.run(warmup.warm_up_indexes())
     assert warmup.INDEX_STATUS["idx"] is True
@@ -30,6 +31,7 @@ def test_warm_up_failure(monkeypatch):
             raise ValueError("boom")
 
     monkeypatch.setattr(warmup, "get_answer_chain", lambda name: Dummy())
+    monkeypatch.setattr(warmup, "get_agent_executor", lambda name: Dummy())
 
     asyncio.run(warmup.warm_up_indexes())
     assert warmup.INDEX_STATUS["idx"] is False


### PR DESCRIPTION
## Summary
- implement agent module using LangChain AgentExecutor
- expose `/agent-chat` endpoint
- warm up agent executors with other chains
- document agent-chat endpoint
- test router, caching, and warmup

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685453cb3c008325b2ab7ade9766d834