### PR TITLE
Improve retrieval logging and debug document fetch

### DIFF
--- a/drsearch_backend/app/chain/engine.py
+++ b/drsearch_backend/app/chain/engine.py
@@ -138,6 +138,14 @@ class ChatEngine:
             ]
         )
 
+        logger.info(
+            "Initialising chat engine",
+            extra={
+                "index": self._index_name,
+                "retrieval_enabled": enable_retrieval,
+            },
+        )
+
         if enable_retrieval and raw_retriever is not None:
             # decomposer_prompt = PromptTemplate.from_template(System_Prompts.REPHRASE_TEMPLATE)
             retriever = MultiQueryRetriever.from_llm(
@@ -195,24 +203,57 @@ class ChatEngine:
         condense_prompt = PromptTemplate.from_template(System_Prompts.REPHRASE_TEMPLATE)
         condense = condense_prompt | self._llm | StrOutputParser()
 
+        def _log_query(query: str) -> str:
+            logger.info(
+                "Retrieval query",
+                extra={"index": self._index_name, "query": query},
+            )
+            return query
+
         def _modify_docs(docs: List[Document]) -> List[Document]:
             # Enrich docs with UNC path when mapping present
             mapping = self._mapping.data
             if mapping is None:
+                logger.info(
+                    "Retrieved %d documents", len(docs),
+                    extra={"index": self._index_name, "doc_count": len(docs)},
+                )
+                if not docs:
+                    logger.warning(
+                        "No documents retrieved", extra={"index": self._index_name}
+                    )
                 return docs
             for doc in docs:
                 filename = doc.metadata.get("filename", "")
                 if filename in mapping:
                     doc.metadata["file_path"] = mapping[filename]
+            logger.info(
+                "Retrieved %d documents", len(docs),
+                extra={
+                    "index": self._index_name,
+                    "doc_count": len(docs),
+                    "filenames": [d.metadata.get("filename") for d in docs],
+                },
+            )
+            if not docs:
+                logger.warning(
+                    "No documents retrieved", extra={"index": self._index_name}
+                )
             return docs
 
-        base_chain = condense | retriever | RunnableLambda(_modify_docs)
+        base_chain = (
+            condense
+            | RunnableLambda(_log_query)
+            | retriever
+            | RunnableLambda(_modify_docs)
+        )
         history_branch = (
             RunnableLambda(lambda d: bool(d.get("chat_history"))),
             base_chain,
         )
         no_history_branch = (
             RunnableLambda(itemgetter("question"))
+            | RunnableLambda(_log_query)
             | retriever
             | RunnableLambda(_modify_docs)
         )

--- a/drsearch_backend/app/chain/formatter.py
+++ b/drsearch_backend/app/chain/formatter.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from typing import Sequence
+import logging
 
 from langchain_community.document_transformers import LongContextReorder
 from langchain_core.documents import Document
 
 from app.chain.mapping import PartNumberMapping
 from app.core import chain_config
+
+
+logger = logging.getLogger(__name__)
 
 
 class DocumentFormatter:
@@ -30,6 +34,14 @@ class DocumentFormatter:
             self._reorder.transform_documents(unique_docs)
             if self._reorder
             else unique_docs
+        )
+
+        logger.info(
+            "Formatting documents",
+            extra={
+                "doc_count": len(docs_reordered),
+                "filenames": [d.metadata.get("filename") for d in docs_reordered],
+            },
         )
 
         formatted: list[str] = []


### PR DESCRIPTION
## Summary
- enhance logging inside ChatEngine to capture query and retrieved document info
- add formatting logs in DocumentFormatter
- highlight retrieval configuration when chat engine initializes

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- manual log inspection after starting server

------
https://chatgpt.com/codex/tasks/task_e_685979c17ce083259f91c3faf1d468cd