### PR TITLE
Improve backend retrieval logging

### DIFF
--- a/drsearch_backend/app/vectorstores/azure_store.py
+++ b/drsearch_backend/app/vectorstores/azure_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 import logging
+from app.vectorstores.retriever_wrappers import LoggedRetriever
 
 logger = logging.getLogger(__name__)
 
@@ -29,24 +30,4 @@ class AzureVectorStore(VectorStore):
 
     def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
         base = self._store.as_retriever(search_kwargs=search_kwargs)
-
-        class _LoggedRetriever(BaseRetriever):
-            def _get_relevant_documents(self, query: str, *, run_manager=None):
-                docs = base.get_relevant_documents(query)
-                logger.info(
-                    "retriever returned %d documents",
-                    len(docs),
-                    extra={"query": query, "doc_count": len(docs)},
-                )
-                return docs
-
-            async def _aget_relevant_documents(self, query: str, *, run_manager=None):
-                docs = await base.ainvoke(query)
-                logger.info(
-                    "retriever returned %d documents",
-                    len(docs),
-                    extra={"query": query, "doc_count": len(docs)},
-                )
-                return docs
-
-        return _LoggedRetriever()
+        return LoggedRetriever(base)

--- a/drsearch_backend/app/vectorstores/azure_store.py
+++ b/drsearch_backend/app/vectorstores/azure_store.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from typing import Any
+import logging
+
+logger = logging.getLogger(__name__)
 
 from langchain_community.vectorstores.azuresearch import (
     AzureSearch as LangchainAzureSearch,
@@ -25,4 +28,25 @@ class AzureVectorStore(VectorStore):
         )
 
     def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
-        return self._store.as_retriever(search_kwargs=search_kwargs)
+        base = self._store.as_retriever(search_kwargs=search_kwargs)
+
+        class _LoggedRetriever(BaseRetriever):
+            def _get_relevant_documents(self, query: str, *, run_manager=None):
+                docs = base.get_relevant_documents(query)
+                logger.info(
+                    "retriever returned %d documents",
+                    len(docs),
+                    extra={"query": query, "doc_count": len(docs)},
+                )
+                return docs
+
+            async def _aget_relevant_documents(self, query: str, *, run_manager=None):
+                docs = await base.ainvoke(query)
+                logger.info(
+                    "retriever returned %d documents",
+                    len(docs),
+                    extra={"query": query, "doc_count": len(docs)},
+                )
+                return docs
+
+        return _LoggedRetriever()

--- a/drsearch_backend/app/vectorstores/pgvector_store.py
+++ b/drsearch_backend/app/vectorstores/pgvector_store.py
@@ -12,6 +12,7 @@ from app.chain.embeddings import EmbeddingFactory
 from app.core import chain_config
 from app.index_config import INDEX_CONFIG
 
+
 from . import VectorStore
 
 
@@ -94,3 +95,13 @@ class PgVectorStore(VectorStore):
                 return _strip(docs)
 
         return _FilteredRetriever()
+    
+
+
+    # def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
+    #     kw = dict(search_kwargs)
+    #     if "where_filter" in kw:
+    #         kw["filter"] = self._convert_filter(kw.pop("where_filter"))
+    #     base = self._store.as_retriever(search_kwargs=kw)
+    #     return FilteredLoggedRetriever(base, allowed_metadata_keys=self._attributes)
+

--- a/drsearch_backend/app/vectorstores/pgvector_store.py
+++ b/drsearch_backend/app/vectorstores/pgvector_store.py
@@ -4,6 +4,9 @@ from typing import Any, Iterable
 
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain_core.retrievers import BaseRetriever
+import logging
+
+logger = logging.getLogger(__name__)
 
 from app.chain.embeddings import EmbeddingFactory
 from app.core import chain_config
@@ -69,6 +72,11 @@ class PgVectorStore(VectorStore):
                     else None
                 )
                 docs = base.get_relevant_documents(query, callbacks=callbacks)
+                logger.info(
+                    "retriever returned %d documents",
+                    len(docs),
+                    extra={"query": query, "doc_count": len(docs)},
+                )
                 return _strip(docs)
 
             async def _aget_relevant_documents(self, query: str, *, run_manager=None):  # type: ignore[override]
@@ -78,6 +86,11 @@ class PgVectorStore(VectorStore):
                     else None
                 )
                 docs = await base.ainvoke(query, config={"callbacks": callbacks})
+                logger.info(
+                    "retriever returned %d documents",
+                    len(docs),
+                    extra={"query": query, "doc_count": len(docs)},
+                )
                 return _strip(docs)
 
         return _FilteredRetriever()

--- a/drsearch_backend/app/vectorstores/retriever_wrappers.py
+++ b/drsearch_backend/app/vectorstores/retriever_wrappers.py
@@ -1,0 +1,50 @@
+from typing import Any, Callable, Iterable
+import logging
+
+from langchain_core.retrievers import BaseRetriever
+
+logger = logging.getLogger(__name__)
+
+
+class LoggedRetriever(BaseRetriever):
+    def __init__(self, base: BaseRetriever):
+        self.base = base
+
+    def _get_relevant_documents(self, query: str, *, run_manager=None):
+        docs = self.base.get_relevant_documents(query)
+        logger.info(
+            "retriever returned %d documents",
+            len(docs),
+            extra={"query": query, "doc_count": len(docs)},
+        )
+        return docs
+
+    async def _aget_relevant_documents(self, query: str, *, run_manager=None):
+        docs = await self.base.ainvoke(query)
+        logger.info(
+            "retriever returned %d documents",
+            len(docs),
+            extra={"query": query, "doc_count": len(docs)},
+        )
+        return docs
+
+
+# This class was created to use in app\vectorstores\pgvector_store.py class '_FilteredRetriever' for modularity.
+# However, this has no been integrated into app\vectorstores\pgvector_store.py PgVectorStore.as_retriever() 
+class FilteredLoggedRetriever(LoggedRetriever):
+    def __init__(self, base: BaseRetriever, allowed_metadata_keys: Iterable[str]):
+        super().__init__(base)
+        self.allowed = set(allowed_metadata_keys)
+
+    def _strip(self, docs):
+        for doc in docs:
+            doc.metadata = {k: v for k, v in doc.metadata.items() if k in self.allowed}
+        return docs
+
+    def _get_relevant_documents(self, query: str, *, run_manager=None):
+        docs = super()._get_relevant_documents(query, run_manager=run_manager)
+        return self._strip(docs)
+
+    async def _aget_relevant_documents(self, query: str, *, run_manager=None):
+        docs = await super()._aget_relevant_documents(query, run_manager=run_manager)
+        return self._strip(docs)

--- a/drsearch_backend/app/vectorstores/retriever_wrappers.py
+++ b/drsearch_backend/app/vectorstores/retriever_wrappers.py
@@ -1,3 +1,4 @@
+
 from typing import Any, Callable, Iterable
 import logging
 
@@ -29,8 +30,6 @@ class LoggedRetriever(BaseRetriever):
         return docs
 
 
-# This class was created to use in app\vectorstores\pgvector_store.py class '_FilteredRetriever' for modularity.
-# However, this has no been integrated into app\vectorstores\pgvector_store.py PgVectorStore.as_retriever() 
 class FilteredLoggedRetriever(LoggedRetriever):
     def __init__(self, base: BaseRetriever, allowed_metadata_keys: Iterable[str]):
         super().__init__(base)

--- a/drsearch_backend/app/vectorstores/weaviate_store.py
+++ b/drsearch_backend/app/vectorstores/weaviate_store.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from typing import Any
+import logging
+
+logger = logging.getLogger(__name__)
 
 import weaviate
 from langchain_community.vectorstores import Weaviate as LangchainWeaviate
@@ -33,5 +36,27 @@ class WeaviateVectorStore(VectorStore):
             attributes=cfg["attributes"],
         )
 
+
     def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
-        return self._store.as_retriever(search_kwargs=search_kwargs)
+        base = self._store.as_retriever(search_kwargs=search_kwargs)
+
+        class _LoggedRetriever(BaseRetriever):
+            def _get_relevant_documents(self, query: str, *, run_manager=None):
+                docs = base.get_relevant_documents(query)
+                logger.info(
+                    "retriever returned %d documents",
+                    len(docs),
+                    extra={"query": query, "doc_count": len(docs)},
+                )
+                return docs
+
+            async def _aget_relevant_documents(self, query: str, *, run_manager=None):
+                docs = await base.ainvoke(query)
+                logger.info(
+                    "retriever returned %d documents",
+                    len(docs),
+                    extra={"query": query, "doc_count": len(docs)},
+                )
+                return docs
+
+        return _LoggedRetriever()

--- a/drsearch_backend/app/vectorstores/weaviate_store.py
+++ b/drsearch_backend/app/vectorstores/weaviate_store.py
@@ -12,6 +12,7 @@ from langchain_core.retrievers import BaseRetriever
 from app.chain.embeddings import EmbeddingFactory
 from app.core import chain_config
 from app.index_config import INDEX_CONFIG
+from app.vectorstores.retriever_wrappers import LoggedRetriever
 
 from . import VectorStore
 
@@ -39,24 +40,4 @@ class WeaviateVectorStore(VectorStore):
 
     def as_retriever(self, search_kwargs: dict[str, Any]) -> BaseRetriever:
         base = self._store.as_retriever(search_kwargs=search_kwargs)
-
-        class _LoggedRetriever(BaseRetriever):
-            def _get_relevant_documents(self, query: str, *, run_manager=None):
-                docs = base.get_relevant_documents(query)
-                logger.info(
-                    "retriever returned %d documents",
-                    len(docs),
-                    extra={"query": query, "doc_count": len(docs)},
-                )
-                return docs
-
-            async def _aget_relevant_documents(self, query: str, *, run_manager=None):
-                docs = await base.ainvoke(query)
-                logger.info(
-                    "retriever returned %d documents",
-                    len(docs),
-                    extra={"query": query, "doc_count": len(docs)},
-                )
-                return docs
-
-        return _LoggedRetriever()
+        return LoggedRetriever(base)


### PR DESCRIPTION
## Summary
- add module-level loggers
- record retrieved document counts in pgvector, weaviate, and Azure stores

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_685979c17ce083259f91c3faf1d468cd