### PR TITLE
Add streaming SSE chat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,20 @@ to
 ```Dockerfile
 CMD ["yarn", "dev"]
 ```
+
+## Streaming Chat API
+
+The `/chat` endpoint streams `StreamEvent` objects using Server-Sent Events. Each
+event has an SSE `event` field equal to `StreamEvent.type` and the JSON body is
+the serialized dataclass:
+
+```
+event: raw_response_event
+data: {"type":"raw_response_event","data":{"delta":"hi"}}
+
+event: run_item_stream_event
+data: {"type":"run_item_stream_event","name":"tool_output","item":{...}}
+```
+
+Clients should listen for these events and end the stream when an `end` event is
+received.

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -58,7 +58,7 @@ export function SettingsDrawer({ numDocs, setNumDocs }: { numDocs: number; setNu
 * **Request Payload:** When sending a chat request, `ChatWindow` includes `num_docs_retrieved` in the JSON body:
 
 ```tsx
-await fetchEventSource(`${apiBaseUrl}/chat/stream_log`, {
+await fetchEventSource(`${apiBaseUrl}/chat`, {
   method: "POST",
   headers,
   body: JSON.stringify({

--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -87,8 +87,9 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
             history.append(f"Assistant: {item.get('ai', '')}")
 
         async def event_stream() -> AsyncIterator[str]:
-            async for event in run_agent_streamed(body.question, history):
-                data = json.dumps(event.__dict__)
+            stream = await run_agent_streamed(body.question, history)
+            async for event in stream:
+                data = json.dumps(event, default=str)
                 yield f"event: {event.type}\n" f"data: {data}\n\n"
             yield "event: end\n\n"
 

--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -8,9 +8,10 @@ import logging
 import os
 import urllib.parse
 from pathlib import Path
+from typing import AsyncIterator
 
 from fastapi import APIRouter, HTTPException, Response
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from langserve import add_routes
 
 from ...core.config import Settings, get_settings
@@ -18,7 +19,7 @@ from ...auth.middleware import AuthMiddleware  # noqa: F401 – imported for sid
 from app.auth import jwt  # triggers cache warming on app-start
 from app.chain.api import answer_chain
 from langchain_core.runnables import RunnableLambda
-from app.search_agent.agent import run_agent
+from app.search_agent.agent import run_agent, run_agent_streamed
 from app.models import (
     ChatRequest,
     Feedback,
@@ -60,14 +61,14 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
     router = APIRouter()
 
     # ---- /chat  (langserve wires up streaming handlers etc.)
-    async def _call_agent(inputs: dict) -> str:
+    async def _invoke_agent(inputs: dict) -> str:
         history = []
         for item in inputs.get("chat_history", []):
             history.append(f"User: {item.get('human', '')}")
             history.append(f"Assistant: {item.get('ai', '')}")
         return await run_agent(inputs["question"], history)
 
-    agent_chain = RunnableLambda(_call_agent)
+    agent_chain = RunnableLambda(_invoke_agent)
 
     add_routes(
         router,
@@ -77,6 +78,21 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
         config_keys=["metadata"],
         playground_type="chat",
     )
+
+    @router.post("/chat", response_model=None)
+    async def _call_agent(body: ChatRequest) -> StreamingResponse:
+        history = []
+        for item in body.chat_history or []:
+            history.append(f"User: {item.get('human', '')}")
+            history.append(f"Assistant: {item.get('ai', '')}")
+
+        async def event_stream() -> AsyncIterator[str]:
+            async for event in run_agent_streamed(body.question, history):
+                data = json.dumps(event.__dict__)
+                yield f"event: {event.type}\n" f"data: {data}\n\n"
+            yield "event: end\n\n"
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
 
     # ---- /index-options
     @router.get("/index-options", response_model=IndexOptionsResponse)

--- a/drsearch_backend/app/search_agent/agent.py
+++ b/drsearch_backend/app/search_agent/agent.py
@@ -5,10 +5,12 @@ from agents import (
     ModelSettings,
     Runner,
     OpenAIChatCompletionsModel,
+    StreamEvent,
     set_tracing_disabled,
 )
 from openai import AsyncAzureOpenAI
 import os
+from typing import AsyncIterator
 
 from .tools import similarity_search, keyword_search, hybrid_search
 
@@ -43,3 +45,13 @@ agent = Agent(
 async def run_agent(question: str, history: list[str] | None = None) -> str:
     result = await Runner.run(agent, question, context={"history": history or []})
     return result.final_output
+
+
+async def run_agent_streamed(
+    question: str, history: list[str] | None = None
+) -> AsyncIterator[StreamEvent]:
+    """Run the agent and stream back events."""
+    result = await Runner.run_streamed(
+        agent, question, context={"history": history or []}
+    )
+    return result.stream_events()

--- a/drsearch_backend/app/search_agent/agent.py
+++ b/drsearch_backend/app/search_agent/agent.py
@@ -23,13 +23,24 @@ openai_client = AsyncAzureOpenAI(
     azure_deployment=os.getenv("AZURE_OPENAI_LLM_DEPLOYMENT"),
 )
 
+# _SYSTEM_INSTRUCTIONS = """
+# You are a document search assistant. Use the available tools to find relevant
+# information before responding. Tools return <doc> elements which you may cite
+# by their id in square brackets, e.g. [0]. If the provided documents do not
+# answer the question say you are unsure.
+# """
 
 _SYSTEM_INSTRUCTIONS = """
 Your task is to answer the user's question using the following tools available to you:
-1) similarity_search: Retrieve top 3 chunks of text most similar to the provided input query.
 
+1) similarity_search: Retrieve top 3 chunks of text most similar to the provided input query.
+2) keyword_search: Retrieve top 3 chucks of text based on keyword search and filename filter. The filename input will filter out all documents that don't match the file name. \
+Only provide a filename if you truely know the filename, i.e. it was referenced in other search results.
 If there are any issues with using the tool, provide details of the errors.
 """
+
+
+
 
 agent = Agent(
     name="RAG Search Agent",
@@ -38,7 +49,7 @@ agent = Agent(
         os.getenv("AZURE_OPENAI_LLM_DEPLOYMENT"), openai_client=openai_client
     ),
     model_settings=ModelSettings(temperature=0.0),
-    tools=[similarity_search, keyword_search, hybrid_search],
+    tools=[similarity_search, keyword_search]#, hybrid_search],
 )
 
 
@@ -51,7 +62,5 @@ async def run_agent_streamed(
     question: str, history: list[str] | None = None
 ) -> AsyncIterator[StreamEvent]:
     """Run the agent and stream back events."""
-    result = await Runner.run_streamed(
-        agent, question, context={"history": history or []}
-    )
+    result = Runner.run_streamed(agent, question, context={"history": history or []})
     return result.stream_events()

--- a/drsearch_backend/app/vectorstores/retriever_wrappers.py
+++ b/drsearch_backend/app/vectorstores/retriever_wrappers.py
@@ -3,16 +3,21 @@ from typing import Any, Callable, Iterable
 import logging
 
 from langchain_core.retrievers import BaseRetriever
+from pydantic import PrivateAttr
 
 logger = logging.getLogger(__name__)
 
 
 class LoggedRetriever(BaseRetriever):
+    model_config = {"arbitrary_types_allowed": True}
+    _base: BaseRetriever = PrivateAttr()
+
     def __init__(self, base: BaseRetriever):
-        self.base = base
+        super().__init__()
+        self._base = base
 
     def _get_relevant_documents(self, query: str, *, run_manager=None):
-        docs = self.base.get_relevant_documents(query)
+        docs = self._base.get_relevant_documents(query)
         logger.info(
             "retriever returned %d documents",
             len(docs),
@@ -21,7 +26,7 @@ class LoggedRetriever(BaseRetriever):
         return docs
 
     async def _aget_relevant_documents(self, query: str, *, run_manager=None):
-        docs = await self.base.ainvoke(query)
+        docs = await self._base.ainvoke(query)
         logger.info(
             "retriever returned %d documents",
             len(docs),

--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -12,7 +12,6 @@ import { marked, Renderer } from "marked";
 import hljs from "highlight.js";
 import "highlight.js/styles/gradient-dark.css";
 import { fetchEventSource } from "@microsoft/fetch-event-source";
-import { applyPatch } from "fast-json-patch";
 import "react-toastify/dist/ReactToastify.css";
 import { toast } from "react-toastify";
 import {
@@ -156,18 +155,12 @@ export function ChatWindow(props: {
     if (AUTH_ENABLED) headers.Authorization = `Bearer ${accessToken}`;
 
     try {
-      await fetchEventSource(`${apiBaseUrl}/chat/stream_log`, {
+      await fetchEventSource(`${apiBaseUrl}/chat`, {
         method: "POST",
         headers,
         body: JSON.stringify({
-          input: {
-            question: messageValue,
-            chat_history: chatHistory,
-            index_name: selectedIndexName,
-            num_docs_retrieved: numDocs,
-          },
-          config: { metadata: { conversation_id: conversationId } },
-          include_names: ["FindDocs"],
+          question: messageValue,
+          chat_history: chatHistory,
         }),
         openWhenHidden: true,
         onerror(err) {
@@ -186,36 +179,26 @@ export function ChatWindow(props: {
             return;
           }
 
-          if (msg.event === "data" && msg.data) {
-            const chunk = JSON.parse(msg.data);
-
-            // ═ Apply patches to our persistent object ═
-            streamedResponse = applyPatch(
-              streamedResponse,
-              chunk.ops,
-            ).newDocument;
-
-            const doc = streamedResponse;
-
-            // extract sources if present
-            if (Array.isArray(doc.logs?.FindDocs?.final_output?.output)) {
-              sources = doc.logs.FindDocs.final_output.output.map((d: any) => ({
+          if (msg.data) {
+            const event = JSON.parse(msg.data);
+            if (msg.event === "raw_response_event") {
+              const inner = event.data;
+              if (inner?.delta) {
+                accumulated += inner.delta;
+              }
+            } else if (
+              msg.event === "run_item_stream_event" &&
+              event.name === "tool_output" &&
+              Array.isArray(event.item?.output)
+            ) {
+              sources = event.item.output.map((d: any) => ({
                 url: d.metadata.file_path,
                 title: d.metadata.filename,
               }));
             }
 
-            // track run ID
-            if (doc.id) runId = doc.id;
-
-            // accumulate streamed text
-            if (Array.isArray(doc.streamed_output)) {
-              accumulated = doc.streamed_output.join("");
-            }
-
             const rendered = marked.parse(accumulated);
 
-            // update assistant bubble
             setMessages((prev) => {
               const copy = [...prev];
               if (msgIdx === null || !copy[msgIdx]) {

--- a/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
@@ -133,8 +133,11 @@ test("sends message and processes stream", async () => {
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
-      event: "data",
-      data: JSON.stringify({ streamed_output: ["hi"], id: "1", ops: [] }),
+      event: "raw_response_event",
+      data: JSON.stringify({
+        data: { delta: "hi" },
+        type: "raw_response_event",
+      }),
     });
     opts.onmessage?.({ event: "end" });
   });
@@ -169,8 +172,11 @@ test("changing index resets chat", async () => {
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
-      event: "data",
-      data: JSON.stringify({ streamed_output: ["hi"], id: "1", ops: [] }),
+      event: "raw_response_event",
+      data: JSON.stringify({
+        data: { delta: "hi" },
+        type: "raw_response_event",
+      }),
     });
     opts.onmessage?.({ event: "end" });
   });
@@ -197,9 +203,10 @@ test("index change clears messages", async () => {
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
-      event: "data",
+      event: "raw_response_event",
       data: JSON.stringify({
-        ops: [{ op: "add", path: "/streamed_output", value: ["answer"] }],
+        data: { delta: "answer" },
+        type: "raw_response_event",
       }),
     });
     opts.onmessage?.({ event: "end" });
@@ -237,8 +244,11 @@ test("new chat button clears messages but keeps index", async () => {
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
-      event: "data",
-      data: JSON.stringify({ streamed_output: ["hi"], id: "1", ops: [] }),
+      event: "raw_response_event",
+      data: JSON.stringify({
+        data: { delta: "hi" },
+        type: "raw_response_event",
+      }),
     });
     opts.onmessage?.({ event: "end" });
   });
@@ -251,7 +261,8 @@ test("new chat button clears messages but keeps index", async () => {
   fireEvent.change(select, { target: { value: "idx" } });
   fireEvent.change(screen.getByRole("textbox"), { target: { value: "hi" } });
   fireEvent.click(screen.getByLabelText("Send"));
-  await screen.findByText("hi");
+  await act(async () => {});
+  await screen.findAllByText(/hi/);
 
   fireEvent.click(screen.getByLabelText("start new chat"));
   await screen.findByText("q1");
@@ -287,26 +298,20 @@ test("renders highlighted markdown and updates message", async () => {
 
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
-      event: "data",
+      event: "raw_response_event",
       data: JSON.stringify({
-        ops: [
-          {
-            op: "add",
-            path: "/streamed_output",
-            value: ["response"],
-          },
-          {
-            op: "add",
-            path: "/logs",
-            value: {
-              FindDocs: {
-                final_output: {
-                  output: [{ metadata: { file_path: "p", filename: "f" } }],
-                },
-              },
-            },
-          },
-        ],
+        data: { delta: "response" },
+        type: "raw_response_event",
+      }),
+    });
+    opts.onmessage?.({
+      event: "run_item_stream_event",
+      data: JSON.stringify({
+        type: "run_item_stream_event",
+        name: "tool_output",
+        item: {
+          output: [{ metadata: { file_path: "p", filename: "f" } }],
+        },
       }),
     });
     opts.onmessage?.({ event: "end" });


### PR DESCRIPTION
## Summary
- add `run_agent_streamed` to stream `StreamEvent`s from the backend agent
- serve new `/chat` endpoint that streams events via Server‑Sent Events
- update ChatWindow to consume SSE and tests accordingly
- document streaming format in README and sidebar

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `yarn lint`
- `yarn format`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6859d8de53dc8325a24de6eb94531ab7