### PR TITLE
Add FastAPI backend simulator

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -1,85 +1,95 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-import json
-from typing import List, Any
+import asyncio, json, uuid
+from typing import List, Dict, Any
 
-app = FastAPI()
+app = FastAPI(title="DRSearch Backend Simulator")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-feedback_log: List[Any] = []
+feedback_log: List[Dict[str, Any]] = []
 
+# ----------------------------- index options -----------------------------
+@app.get("/index-options")
+async def get_index_options() -> Dict[str, Any]:
+    """Return mock index metadata (matches IndexOptionsResponse)."""
+    return {
+        "result": [
+            {
+                "name": "Demo_Index_1",
+                "display_name": "Demo Index 1",
+                "example_questions": [
+                    "What is Demo Index 1 used for?",
+                    "How to use Demo Index 1?",
+                ],
+                "initialized": True,
+            },
+            {
+                "name": "Demo_Index_2",
+                "display_name": "Demo Index 2",
+                "example_questions": [
+                    "Sample question for index 2?",
+                    "Another example query?",
+                ],
+                "initialized": False,
+            },
+        ],
+        "code": 200,
+    }
+
+# ------------------------------- feedback -------------------------------
+@app.post("/feedback")
+async def post_feedback(request: Request) -> Dict[str, Any]:
+    """Accept feedback payload and keep it in memory for the session."""
+    payload = await request.json()
+    feedback_log.append(payload)
+    print(f"[Simulator] Feedback received: {payload}")
+    return {"result": "posted feedback successfully", "code": 200}
+
+# ---------------------------- streaming chat ----------------------------
 @app.post("/chat/stream_log")
-async def chat_stream(request: Request):
+async def chat_stream(request: Request) -> StreamingResponse:
+    """Simulate LangServe /chat streaming via SSE."""
     body = await request.json()
+    print(f"[Simulator] Received chat payload: {body}")
+
     user_question = body.get("input", {}).get("question")
     index_name = body.get("input", {}).get("index_name")
-    print(f"[Simulator] Received question: {user_question}")
-    if index_name:
-        print(f"[Simulator] Index requested: {index_name}")
-    auth_header = request.headers.get("authorization")
-    if auth_header:
-        print(f"[Simulator] Authorization header: {auth_header}")
+    print(f"[Simulator] Question: {user_question} | Index: {index_name}")
 
-    def event_stream():
-        partial1 = "Hello, "
-        partial2 = "this is a demo."
-        chunk1 = {
-            "ops": [
-                {"op": "add", "path": "/streamed_output", "value": []},
-                {"op": "add", "path": "/streamed_output/0", "value": partial1},
-            ],
-            "id": "sim-run-123",
-            "streamed_output": [partial1],
-        }
-        yield f"event: data\ndata: {json.dumps(chunk1)}\n\n"
-        chunk2 = {
-            "ops": [
-                {"op": "add", "path": "/streamed_output/1", "value": partial2},
-            ],
-            "id": "sim-run-123",
-            "streamed_output": [partial1, partial2],
-        }
-        yield f"event: data\ndata: {json.dumps(chunk2)}\n\n"
+    run_id = str(uuid.uuid4())
+    partials = ["Hello, ", "this is a demo."]
+
+    async def event_stream():
+        streamed: List[str] = []
+        for i, chunk in enumerate(partials):
+            streamed.append(chunk)
+            payload = {
+                "ops": (
+                    [{"op": "add", "path": "/streamed_output", "value": []}]
+                    if i == 0
+                    else []
+                )
+                + [
+                    {"op": "add", "path": f"/streamed_output/{i}", "value": chunk},
+                ],
+                "id": run_id,
+                "streamed_output": streamed,
+            }
+            yield f"event: data\ndata: {json.dumps(payload)}\n\n"
+            await asyncio.sleep(0.2)
         yield "event: end\n\n"
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
 
+# ------------------------------- run uvicorn ------------------------------
+if __name__ == "__main__":
+    import uvicorn
 
-@app.get("/index-options")
-async def get_index_options():
-    index_list = [
-        {
-            "name": "Demo_Index_1",
-            "display_name": "Demo Index 1",
-            "example_questions": [
-                "What is Demo Index 1 used for?",
-                "How to use Demo Index 1?",
-            ],
-            "initialized": True,
-        },
-        {
-            "name": "Demo_Index_2",
-            "display_name": "Demo Index 2",
-            "example_questions": [
-                "Sample question for index 2?",
-                "Another example query?",
-            ],
-            "initialized": False,
-        },
-    ]
-    return {"result": index_list, "code": 200}
-
-
-@app.post("/feedback")
-async def post_feedback(request: Request):
-    feedback_data = await request.json()
-    feedback_log.append(feedback_data)
-    print(f"[Simulator] Feedback received: {feedback_data}")
-    return {"result": "posted feedback successfully", "code": 200}
-
+    uvicorn.run("simulator:app", host="0.0.0.0", port=8011, reload=True)

--- a/simulator.py
+++ b/simulator.py
@@ -1,0 +1,85 @@
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+import json
+from typing import List, Any
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+feedback_log: List[Any] = []
+
+@app.post("/chat/stream_log")
+async def chat_stream(request: Request):
+    body = await request.json()
+    user_question = body.get("input", {}).get("question")
+    index_name = body.get("input", {}).get("index_name")
+    print(f"[Simulator] Received question: {user_question}")
+    if index_name:
+        print(f"[Simulator] Index requested: {index_name}")
+    auth_header = request.headers.get("authorization")
+    if auth_header:
+        print(f"[Simulator] Authorization header: {auth_header}")
+
+    def event_stream():
+        partial1 = "Hello, "
+        partial2 = "this is a demo."
+        chunk1 = {
+            "ops": [
+                {"op": "add", "path": "/streamed_output", "value": []},
+                {"op": "add", "path": "/streamed_output/0", "value": partial1},
+            ],
+            "id": "sim-run-123",
+            "streamed_output": [partial1],
+        }
+        yield f"event: data\ndata: {json.dumps(chunk1)}\n\n"
+        chunk2 = {
+            "ops": [
+                {"op": "add", "path": "/streamed_output/1", "value": partial2},
+            ],
+            "id": "sim-run-123",
+            "streamed_output": [partial1, partial2],
+        }
+        yield f"event: data\ndata: {json.dumps(chunk2)}\n\n"
+        yield "event: end\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+@app.get("/index-options")
+async def get_index_options():
+    index_list = [
+        {
+            "name": "Demo_Index_1",
+            "display_name": "Demo Index 1",
+            "example_questions": [
+                "What is Demo Index 1 used for?",
+                "How to use Demo Index 1?",
+            ],
+            "initialized": True,
+        },
+        {
+            "name": "Demo_Index_2",
+            "display_name": "Demo Index 2",
+            "example_questions": [
+                "Sample question for index 2?",
+                "Another example query?",
+            ],
+            "initialized": False,
+        },
+    ]
+    return {"result": index_list, "code": 200}
+
+
+@app.post("/feedback")
+async def post_feedback(request: Request):
+    feedback_data = await request.json()
+    feedback_log.append(feedback_data)
+    print(f"[Simulator] Feedback received: {feedback_data}")
+    return {"result": "posted feedback successfully", "code": 200}
+


### PR DESCRIPTION
## Summary
- create a minimal FastAPI simulator with `/chat/stream_log`, `/index-options` and `/feedback`
- enable permissive CORS for local testing

## Testing
- `cd drsearch_backend && poetry run pytest --cov=app --cov-report=term-missing -q`
- `cd ../drsearch_frontend && yarn lint`
- `yarn format`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685a9f4516688325aa0225c818259ad6