### PR TITLE
Add Playwright end-to-end harness

### DIFF
--- a/testing/e2e.spec.ts
+++ b/testing/e2e.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const base = path.resolve(__dirname);
+const payloads = [1,2,3].map(n =>
+  JSON.parse(fs.readFileSync(path.join(base, `payload${n}.json`), 'utf-8'))
+);
+const traces = [1,2,3].map(n =>
+  fs.readFileSync(path.join(base, 'traces', `trace${n}.sse`), 'utf-8')
+);
+
+function finalOutput(trace: string): string {
+  const regex = /"final_output".*?\"(?:output\"\:\")?([^\"]+)/gs;
+  let m: RegExpExecArray | null;
+  let last = '';
+  while ((m = regex.exec(trace))) {
+    last = m[1];
+  }
+  return last;
+}
+
+test.describe('trace replays', () => {
+  payloads.forEach((payload, idx) => {
+    const trace = traces[idx];
+    const expectedTail = finalOutput(trace).slice(-20);
+
+    test(`payload ${idx + 1}`, async ({ page }) => {
+      const errors: any[] = [];
+      page.on('pageerror', err => errors.push(err));
+
+      await page.route('**/chat/stream_log', async route => {
+        const sent = JSON.parse(route.request().postData() || '{}');
+        expect(sent).toEqual(payload);
+        await route.continue();
+      });
+
+      await page.goto('http://localhost:3000', { waitUntil: 'networkidle' });
+      await page.getByRole('combobox').selectOption(payload.input.index_name);
+      await page.getByRole('textbox').fill(payload.input.question);
+      await page.getByLabel('Send').click();
+
+      const answer = page.locator('div.whitespace-pre-wrap').last();
+      await expect(answer).toContainText(expectedTail, { timeout: 15000 });
+      expect(errors).toEqual([]);
+    });
+  });
+});

--- a/testing/payload1.json
+++ b/testing/payload1.json
@@ -1,0 +1,9 @@
+{
+  "input": {
+    "question": "How do I test a next.js frontend?",
+    "chat_history": [{"human": "Hi", "ai": "Hello!"}],
+    "index_name": "TEST_INDEX",
+    "num_docs_retrieved": 2
+  },
+  "include_names": ["FindDocs"]
+}

--- a/testing/payload2.json
+++ b/testing/payload2.json
@@ -1,0 +1,9 @@
+{
+  "input": {
+    "question": "How do I test a FastAPI server?",
+    "chat_history": [{"human": "Hi", "ai": "Hello!"}],
+    "index_name": "TEST_INDEX",
+    "num_docs_retrieved": 1
+  },
+  "include_names": ["FindDocs"]
+}

--- a/testing/payload3.json
+++ b/testing/payload3.json
@@ -1,0 +1,9 @@
+{
+  "input": {
+    "question": "How do I complete an audit?",
+    "chat_history": [{"human": "Hi", "ai": "Hello!"}],
+    "index_name": "OTHER_INDEX",
+    "num_docs_retrieved": 3
+  },
+  "include_names": ["FindDocs"]
+}

--- a/testing/run_e2e.sh
+++ b/testing/run_e2e.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+uvicorn testing.simulator:app --port 8011 --reload > simulator.log 2>&1 &
+SIM_PID=$!
+
+pushd drsearch_frontend >/dev/null
+yarn install --silent
+API_BASE_URL=http://localhost:8011 yarn dev -p 3000 > ../frontend.log 2>&1 &
+FRONT_PID=$!
+popd >/dev/null
+
+for i in {1..30}; do
+  curl -s http://localhost:8011/last_request >/dev/null 2>&1 && break
+  sleep 1
+done
+for i in {1..30}; do
+  curl -s http://localhost:3000 >/dev/null 2>&1 && break
+  sleep 1
+done
+
+npx playwright install --with-deps
+npx playwright test testing/e2e.spec.ts
+STATUS=$?
+
+kill $FRONT_PID $SIM_PID || true
+exit $STATUS

--- a/testing/simulator.py
+++ b/testing/simulator.py
@@ -1,0 +1,54 @@
+import asyncio
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse, JSONResponse
+from pathlib import Path
+import json
+
+app = FastAPI(title="DRSearch Trace-Replay Simulator")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+TRACES = {
+    "trace1": Path(__file__).parent / "traces" / "trace1.sse",
+    "trace2": Path(__file__).parent / "traces" / "trace2.sse",
+    "trace3": Path(__file__).parent / "traces" / "trace3.sse",
+}
+
+last_request: dict | None = None
+
+@app.post("/chat/stream_log")
+async def chat_stream_log(request: Request):
+    global last_request
+    body = await request.json()
+    last_request = body
+    inp = body.get("input", {})
+    idx = inp.get("index_name")
+    num = inp.get("num_docs_retrieved")
+    if idx == "TEST_INDEX" and num == 2:
+        trace_path = TRACES["trace1"]
+    elif idx == "TEST_INDEX" and num == 1:
+        trace_path = TRACES["trace2"]
+    else:
+        trace_path = TRACES["trace3"]
+
+    async def event_generator():
+        with open(trace_path, "r") as f:
+            for line in f:
+                yield line
+                if line.startswith("event: data"):
+                    await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01)
+        yield "event: end\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+@app.get("/last_request")
+async def get_last_request():
+    return JSONResponse(last_request or {})


### PR DESCRIPTION
## Summary
- add SSE trace simulator for local testing
- add playwright spec driving DRSearch frontend
- add shell wrapper to orchestrate simulator and frontend
- add test payloads matching traces

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `yarn lint`
- `yarn format`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685ac74bb8248325bf817ed203da7326