### PR TITLE
Fix E2E timeout by lowering simulator delay

### DIFF
--- a/drsearch_backend/testing_full_app/simulator.py
+++ b/drsearch_backend/testing_full_app/simulator.py
@@ -57,7 +57,7 @@ def get_trace_file(body: dict) -> Path:
     return TRACES_DIR / name
 
 
-async def stream_lines(fp: Path, delay: float = 0.01, malformed: bool = False):
+async def stream_lines(fp: Path, delay: float = 0.001, malformed: bool = False):
     with fp.open() as f:
         for line in f:
             yield line


### PR DESCRIPTION
## Summary
- decrease the default delay between SSE events in the test simulator
- verify the end-to-end tests (with and without coverage)

## Testing
- `node test_full_app/run-e2e.mjs`
- `COLLECT_COVERAGE=1 node test_full_app/run-e2e.mjs`


------
https://chatgpt.com/codex/tasks/task_e_685d6f2dd4f483259fb2a310a9db7f44