### PR TITLE
Enable Playwright coverage output

### DIFF
--- a/drsearch_frontend/.prettierignore
+++ b/drsearch_frontend/.prettierignore
@@ -1,0 +1,1 @@
+test-results

--- a/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
+++ b/drsearch_frontend/app/utils/__tests__/fetchIndexOptions.test.ts
@@ -23,7 +23,9 @@ test("fetches index options with token", async () => {
   expect(fetch).toHaveBeenCalledWith(apiUrl, {
     headers: { Authorization: "Bearer tok" },
   });
-  expect(res).toEqual([{ name: "a", initialized: true }]);
+  expect(res).toEqual([
+    { name: "a", initialized: true, example_questions: [] },
+  ]);
 });
 
 test("throws error on http failure", async () => {

--- a/drsearch_frontend/testing_full_app/e2e.spec.ts
+++ b/drsearch_frontend/testing_full_app/e2e.spec.ts
@@ -17,6 +17,26 @@ const expectedOutputs = [1, 2, 3].map((i) =>
 
 const baseURL = process.env.FRONTEND_BASE_URL || "http://localhost:3000";
 
+test.beforeEach(async ({ page }, testInfo) => {
+  if (process.env.PW_TEST_COVERAGE) {
+    await page.coverage.startJSCoverage();
+    await page.coverage.startCSSCoverage();
+  }
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  if (process.env.PW_TEST_COVERAGE) {
+    const coverage = {
+      js: await page.coverage.stopJSCoverage(),
+      css: await page.coverage.stopCSSCoverage(),
+    };
+    const file = testInfo.outputPath(
+      `coverage-${testInfo.title.replace(/\W+/g, "_")}.json`,
+    );
+    fs.writeFileSync(file, JSON.stringify(coverage, null, 2));
+  }
+});
+
 test.describe("trace replay happy path", () => {
   payloads.forEach((payload, idx) => {
     // Payload 3 is now enabled and working correctly
@@ -25,7 +45,10 @@ test.describe("trace replay happy path", () => {
       const consoleErrors: string[] = [];
       page.on("pageerror", (e) => consoleErrors.push(e.message));
       page.on("console", (msg) => {
-        if (msg.type() === "error" && !msg.text().includes("Failed to load resource")) {
+        if (
+          msg.type() === "error" &&
+          !msg.text().includes("Failed to load resource")
+        ) {
           consoleErrors.push(msg.text());
         }
       });
@@ -44,7 +67,9 @@ test.describe("trace replay happy path", () => {
         const sel = document.querySelector(
           'select[data-testid="index-select"]',
         ) as HTMLSelectElement;
-        return Array.from(sel?.options || []).some((o: HTMLOptionElement) => o.value === val);
+        return Array.from(sel?.options || []).some(
+          (o: HTMLOptionElement) => o.value === val,
+        );
       }, payload.input.index_name);
       await select.selectOption(payload.input.index_name);
 

--- a/drsearch_frontend/testing_full_app/e2e_negative.spec.ts
+++ b/drsearch_frontend/testing_full_app/e2e_negative.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
+import fs from "fs";
 import { extractFinalOutput } from "./trace_utils";
 import path from "path";
 
@@ -10,19 +11,43 @@ const slowExpected = extractFinalOutput(path.join(tracesDir, "trace3.sse"));
 
 const baseURL = process.env.FRONTEND_BASE_URL || "http://localhost:3000";
 
+test.beforeEach(async ({ page }) => {
+  if (process.env.PW_TEST_COVERAGE) {
+    await page.coverage.startJSCoverage();
+    await page.coverage.startCSSCoverage();
+  }
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  if (process.env.PW_TEST_COVERAGE) {
+    const coverage = {
+      js: await page.coverage.stopJSCoverage(),
+      css: await page.coverage.stopCSSCoverage(),
+    };
+    const file = testInfo.outputPath(
+      `coverage-${testInfo.title.replace(/\W+/g, "_")}.json`,
+    );
+    fs.writeFileSync(file, JSON.stringify(coverage, null, 2));
+  }
+});
+
 async function askQuestion(page: Page, indexName: string) {
   await page.goto(baseURL);
   const select = page.getByTestId("index-select");
   await select.waitFor();
   await page.waitForFunction((val: string) => {
-    const sel = document.querySelector('select[data-testid="index-select"]') as HTMLSelectElement;
-    return Array.from(sel?.options || []).some((o: HTMLOptionElement) => o.value === val);
+    const sel = document.querySelector(
+      'select[data-testid="index-select"]',
+    ) as HTMLSelectElement;
+    return Array.from(sel?.options || []).some(
+      (o: HTMLOptionElement) => o.value === val,
+    );
   }, indexName);
   await select.selectOption(indexName);
-  
+
   // Wait for the page to process the index selection
   await page.waitForTimeout(2000);
-  
+
   // Debug: Check what's currently selected
   const selectedValue = await select.inputValue();
   console.log(`Selected index: ${selectedValue}`);
@@ -32,40 +57,46 @@ async function askQuestion(page: Page, indexName: string) {
 test.describe("negative scenarios", () => {
   test("ERROR_500 displays error", async ({ page }) => {
     await askQuestion(page, "ERROR_500");
-    
+
     // Check if chat input is available, if not, the index might not be properly initialized
     const chatInput = page.getByTestId("chat-input");
     const isChatInputVisible = await chatInput.isVisible().catch(() => false);
-    
+
     if (!isChatInputVisible) {
       // If chat input is not available, check if there's an error message or disabled state
-      await expect(page.locator("text=/backend failure/i")).toBeVisible({ timeout: 5000 });
+      await expect(page.locator("text=/backend failure/i")).toBeVisible({
+        timeout: 5000,
+      });
       return;
     }
-    
+
     // Fill in the question and try to send it
     await chatInput.fill("Why?");
     await page.getByTestId("chat-send-btn").click();
-    
+
     // Wait for the error toast to be displayed - look for the toast container with error text
-    await expect(page.locator('.Toastify__toast--error')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(".Toastify__toast--error")).toBeVisible({
+      timeout: 10000,
+    });
     // The actual error message is about content-type mismatch, not "backend failure"
-    await expect(page.locator('.Toastify__toast--error')).toContainText("content-type");
+    await expect(page.locator(".Toastify__toast--error")).toContainText(
+      "content-type",
+    );
   });
 
   test("SLOW_STREAM completes within default timeout", async ({ page }) => {
     await askQuestion(page, "SLOW_STREAM");
-    
+
     // Check if chat input is available
     const chatInput = page.getByTestId("chat-input");
     const isChatInputVisible = await chatInput.isVisible().catch(() => false);
-    
+
     if (!isChatInputVisible) {
       // If chat input is not available, this test should be skipped or the index should be fixed
       test.skip();
       return;
     }
-    
+
     // Fill in the question and send it
     await chatInput.fill("Why?");
     await page.getByTestId("chat-send-btn").click();
@@ -84,33 +115,36 @@ test.describe("negative scenarios", () => {
     page.on("console", (msg) => {
       if (msg.type() === "error") {
         // Filter out 404 errors for missing resources as they're expected in test environment
-        if (!msg.text().includes("Failed to load resource") && !msg.text().includes("404")) {
+        if (
+          !msg.text().includes("Failed to load resource") &&
+          !msg.text().includes("404")
+        ) {
           errors.push(msg.text());
         }
       }
     });
-    
+
     await askQuestion(page, "MALFORMED_SSE");
-    
+
     // Check if chat input is available
     const chatInput = page.getByTestId("chat-input");
     const isChatInputVisible = await chatInput.isVisible().catch(() => false);
-    
+
     if (!isChatInputVisible) {
       // If chat input is not available, this test should be skipped or the index should be fixed
       test.skip();
       return;
     }
-    
+
     // Fill in the question and send it
     await chatInput.fill("Why?");
     await page.getByTestId("chat-send-btn").click();
-    
+
     // Wait for some response to be visible (even if malformed)
     await expect(page.getByTestId("chat-stream")).toBeVisible({
       timeout: 30000,
     });
-    
+
     // Check that there are no console errors (excluding 404 resource errors)
     expect(errors).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- collect Playwright coverage when PW_TEST_COVERAGE=1
- ignore generated coverage files
- update fetchIndexOptions test to expect example_questions field

## Testing
- `yarn lint`
- `yarn format`
- `yarn test --coverage`
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `COLLECT_COVERAGE=1 node test_full_app/run-e2e.mjs`

------
https://chatgpt.com/codex/tasks/task_e_685d7e2dcc2083258881872de04e2636