### PR TITLE
Store e2e test results in timestamped directory

### DIFF
--- a/test_full_app/TROUBLESHOOTING.md
+++ b/test_full_app/TROUBLESHOOTING.md
@@ -104,10 +104,10 @@ The enhanced logging will show:
    ```
 
 4. **Check logs**:
-   - `test_full_app/logs/simulator1.out.log` - Backend simulator output
-   - `test_full_app/logs/simulator1.err.log` - Backend simulator errors
-   - `test_full_app/logs/frontend1.out.log` - Frontend server output
-   - `test_full_app/logs/frontend1.err.log` - Frontend server errors
+   - `test_full_app/output/<timestamp>/logs/simulator1.out.log` - Backend simulator output
+   - `test_full_app/output/<timestamp>/logs/simulator1.err.log` - Backend simulator errors
+   - `test_full_app/output/<timestamp>/logs/frontend1.out.log` - Frontend server output
+   - `test_full_app/output/<timestamp>/logs/frontend1.err.log` - Frontend server errors
 
 5. **Restore original state**:
    ```bash

--- a/test_full_app/e2e_test_overview.md
+++ b/test_full_app/e2e_test_overview.md
@@ -98,7 +98,7 @@ A helper function within the spec handles the common setup of navigating to the 
 
 ## Coverage
 
-Setting the environment variable `COLLECT_COVERAGE=1` when invoking the harness enables Playwright’s coverage reporting. The resulting coverage files are emitted in the default Playwright output directory inside `drsearch_frontend`.
+Setting the environment variable `COLLECT_COVERAGE=1` when invoking the harness enables Playwright’s coverage reporting. All artifacts including coverage JSON files and Playwright reports are stored under `test_full_app/output/<timestamp>` within the repository. Each run gets its own timestamped folder so reports can be inspected later.
 
 Example:
 

--- a/test_full_app/run-e2e.mjs
+++ b/test_full_app/run-e2e.mjs
@@ -8,8 +8,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, "..");
 const backendDir = resolve(rootDir, "drsearch_backend");
 const frontendDir = resolve(rootDir, "drsearch_frontend");
-const logDir = resolve(__dirname, "logs");
+const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+const outputDir = resolve(__dirname, "output", timestamp);
+const logDir = resolve(outputDir, "logs");
 import { mkdirSync } from "fs";
+mkdirSync(outputDir, { recursive: true });
 mkdirSync(logDir, { recursive: true });
 
 const YARN = process.platform === "win32" ? "yarn.cmd" : "yarn";
@@ -160,10 +163,12 @@ process.on("exit", cleanup);
   }
 
   log("Starting Playwright tests...");
-  log(`Test command: ${NPX} playwright test testing_full_app`);
+  const testResultsDir = resolve(outputDir, "playwright-results");
+  mkdirSync(testResultsDir, { recursive: true });
+  log(`Test command: ${NPX} playwright test testing_full_app --output ${testResultsDir}`);
   log(`Test environment: ${JSON.stringify(env, null, 2)}`);
-  
-  const testProc = spawn(NPX, ["playwright", "test", "testing_full_app", "--reporter=list"], {
+
+  const testProc = spawn(NPX, ["playwright", "test", "testing_full_app", "--reporter=list", "--output", testResultsDir], {
     cwd: frontendDir,
     env,
     stdio: "inherit",

--- a/test_full_app/run_e2e.ps1
+++ b/test_full_app/run_e2e.ps1
@@ -3,8 +3,13 @@ $ErrorActionPreference = 'Stop'
 
 # Get script directory and logs folder
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$LogDir = Join-Path $ScriptDir "logs"
+$timestamp = Get-Date -Format 'yyyy-MM-ddTHH-mm-ss'
+$OutputDir = Join-Path $ScriptDir "output\$timestamp"
+$LogDir = Join-Path $OutputDir 'logs'
 
+if (-not (Test-Path $OutputDir)) {
+    New-Item -Path $OutputDir -ItemType Directory | Out-Null
+}
 if (-not (Test-Path $LogDir)) {
     New-Item -Path $LogDir -ItemType Directory | Out-Null
 }
@@ -54,7 +59,10 @@ try {
 
     # Run Playwright tests
     & yarn playwright install --with-deps
-    & yarn playwright test testing_full_app/e2e.spec.ts
+    if (-not (Test-Path (Join-Path $OutputDir 'playwright-results'))) {
+        New-Item -Path (Join-Path $OutputDir 'playwright-results') -ItemType Directory | Out-Null
+    }
+    & yarn playwright test testing_full_app/e2e.spec.ts --output (Join-Path $OutputDir 'playwright-results')
     $STATUS = $LASTEXITCODE
 }
 finally {

--- a/test_full_app/run_e2e.sh
+++ b/test_full_app/run_e2e.sh
@@ -10,7 +10,9 @@ cleanup() {
 trap cleanup EXIT
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LOG_DIR="$SCRIPT_DIR/logs"
+TIMESTAMP="$(date +%Y-%m-%dT%H-%M-%S)"
+OUTPUT_DIR="$SCRIPT_DIR/output/$TIMESTAMP"
+LOG_DIR="$OUTPUT_DIR/logs"
 mkdir -p "$LOG_DIR"
 
 SIM_OUT_LOG="$LOG_DIR/simulator1.out.log"
@@ -40,8 +42,8 @@ for i in {1..60}; do
 done
 
 cd drsearch_frontend
-
-npx -y playwright test testing_full_app/e2e.spec.ts
+mkdir -p "$OUTPUT_DIR/playwright-results"
+npx -y playwright test testing_full_app/e2e.spec.ts --output "$OUTPUT_DIR/playwright-results"
 STATUS=$?
 
 # Cleanup processes


### PR DESCRIPTION
## Summary
- create timestamped output folder for e2e run
- place all logs and playwright artifacts in that folder
- document new output location for troubleshooting and coverage

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`
- `yarn lint`
- `yarn format`
- `yarn test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_685d97fbe2dc832586003e8c53bbd269