### PR TITLE
Fix backend E2E env and extend coverage

### DIFF
--- a/test_full_app/backend/test_backend_e2e_example.py
+++ b/test_full_app/backend/test_backend_e2e_example.py
@@ -15,6 +15,8 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch
 from pathlib import Path
 
+from .test_config import setup_test_environment
+
 # Add the backend directory to Python path
 backend_dir = Path(__file__).parent.parent.parent / "drsearch_backend"
 test_components_dir = Path(__file__).parent
@@ -24,12 +26,12 @@ sys.path.insert(0, str(test_components_dir))
 # Import the fake components
 try:
     from fake_components import (
-        DeterministicFakeLLM, 
-        DeterministicFakeEmbeddings, 
+        DeterministicFakeLLM,
+        DeterministicFakeEmbeddings,
         FakeVectorRetriever,
         create_test_llm,
         create_test_embeddings,
-        create_test_retriever
+        create_test_retriever,
     )
 except ImportError as e:
     print(f"Failed to import fake components: {e}")
@@ -39,79 +41,60 @@ except ImportError as e:
 class TestBackendE2EExample:
     """
     Example end-to-end tests for the drsearch_backend API.
-    
+
     These tests demonstrate how to:
     1. Use the real FastAPI backend with fake components
     2. Verify API request/response formats
     3. Test streaming endpoints
     4. Validate different query patterns
     """
-    
+
     @pytest.fixture(scope="class")
     def backend_app(self):
         """Create the real backend app with test configuration."""
-        # Set environment variables for testing
-        test_env = {
-            "AUTH_ENABLED": "False",
-            "RAG_ON": "True", 
-            "LLM_SERVICE": "fake",
-            "VECTOR_BACKEND": "test",
-            "LOG_LEVEL": "INFO",
-            # Add other required env vars
-            "WEAVIATE_URL": "http://test:8080",
-            "WEAVIATE_API_KEY": "test-key",
-            "AZURE_OPENAI_API_VERSION": "2024-05-15",
-            "AZURE_OPENAI_DEPLOYMENT_NAME": "test-model",
-            "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com/",
-            "AZURE_OPENAI_API_KEY": "test-key",
-            "AZURE_SEARCH_ENDPOINT": "https://test.search.windows.net",
-            "AZURE_SEARCH_KEY": "test-key",
-            "PGVECTOR_URL": "postgresql://test:test@localhost/test",
-            "CORS_ORIGINS": '["http://localhost:3000"]',
-        }
-        
-        # Apply test environment
-        for key, value in test_env.items():
-            os.environ[key] = value
-        
+        setup_test_environment()
+
         # Patch the backend components with our fake implementations
         try:
-            with patch('app.chain.engine.AzureChatOpenAI', create_test_llm), \
-                 patch('app.chain.embeddings.AzureOpenAIEmbeddings', create_test_embeddings), \
-                 patch('app.chain.retriever.RetrieverFactory.build', create_test_retriever):
-                
+            with patch("app.chain.engine.AzureChatOpenAI", create_test_llm), patch(
+                "app.chain.embeddings.AzureOpenAIEmbeddings", create_test_embeddings
+            ), patch(
+                "app.chain.retriever.RetrieverFactory.build", create_test_retriever
+            ):
+
                 from app import create_app
+
                 yield create_app()
         except ImportError as e:
             # Fallback if imports fail
             print(f"Import error: {e}")
             pytest.skip("Could not import backend app")
-    
+
     @pytest.fixture
     def client(self, backend_app):
         """Create a test client for the backend API."""
         return TestClient(backend_app)
-    
+
     def test_index_options_endpoint(self, client):
         """Test the /index-options endpoint returns correct format."""
         response = client.get("/index-options")
-        
+
         assert response.status_code == 200
         data = response.json()
-        
+
         # Validate response structure
         assert "result" in data
         assert "code" in data
         assert data["code"] == 200
         assert isinstance(data["result"], list)
-        
+
         # Validate each index option
         for index_option in data["result"]:
             assert "name" in index_option
             assert "display_name" in index_option
             assert "initialized" in index_option
             assert "example_questions" in index_option
-    
+
     def test_chat_invoke_basic_query(self, client):
         """Test /chat/invoke with a basic troubleshooting query."""
         payload = {
@@ -119,33 +102,33 @@ class TestBackendE2EExample:
                 "question": "How to troubleshoot system errors?",
                 "chat_history": [],
                 "index_name": "TEST_INDEX",
-                "num_docs_retrieved": 3
+                "num_docs_retrieved": 3,
             }
         }
-        
+
         response = client.post("/chat/invoke", json=payload)
-        
+
         assert response.status_code == 200
         data = response.json()
-        
+
         # Validate response structure
         assert "output" in data
         assert "metadata" in data
-        
+
         # Validate metadata
         metadata = data["metadata"]
         assert "run_id" in metadata
         assert "feedback_tokens" in metadata
-        
+
         # Validate output content
         output = data["output"]
         assert isinstance(output, str)
         assert len(output) > 0
-        
+
         # Since we use deterministic fake LLM, we can test specific content
         assert "troubleshoot" in output.lower()
         assert "steps" in output.lower()
-    
+
     def test_chat_invoke_maintenance_query(self, client):
         """Test /chat/invoke with a maintenance query."""
         payload = {
@@ -153,64 +136,110 @@ class TestBackendE2EExample:
                 "question": "What are the maintenance procedures?",
                 "chat_history": [],
                 "index_name": "TEST_INDEX",
-                "num_docs_retrieved": 2
+                "num_docs_retrieved": 2,
             }
         }
-        
+
         response = client.post("/chat/invoke", json=payload)
-        
+
         assert response.status_code == 200
         data = response.json()
-        
+
         output = data["output"]
         # Deterministic fake LLM should return maintenance-specific content
         assert "maintenance" in output.lower()
         assert "safety" in output.lower() or "procedures" in output.lower()
-    
+
     def test_chat_invoke_with_history(self, client):
         """Test /chat/invoke with chat history."""
         payload = {
             "input": {
                 "question": "What about error handling?",
                 "chat_history": [
-                    {"human": "Tell me about troubleshooting", "ai": "Troubleshooting involves systematic diagnosis..."}
+                    {
+                        "human": "Tell me about troubleshooting",
+                        "ai": "Troubleshooting involves systematic diagnosis...",
+                    }
                 ],
                 "index_name": "TEST_INDEX",
-                "num_docs_retrieved": 3
+                "num_docs_retrieved": 3,
             }
         }
-        
+
         response = client.post("/chat/invoke", json=payload)
-        
+
         assert response.status_code == 200
         data = response.json()
-        
+
         output = data["output"]
         # Should include follow-up context
         assert len(output) > 0
         assert "error" in output.lower()
-    
+
+    @pytest.mark.parametrize("index_name", ["TEST_INDEX", "ALT_INDEX"])
+    def test_chat_invoke_different_indexes(self, client, index_name):
+        """Ensure different index names are accepted."""
+        payload = {
+            "input": {
+                "question": "Check operations?",
+                "chat_history": [],
+                "index_name": index_name,
+                "num_docs_retrieved": 2,
+            }
+        }
+
+        response = client.post("/chat/invoke", json=payload)
+        assert response.status_code == 200
+        assert "output" in response.json()
+
+    def test_authentication_required(self):
+        """Authentication enabled should enforce auth headers."""
+        setup_test_environment({"AUTH_ENABLED": "True"})
+        from app import create_app
+
+        app = create_app()
+        test_client = TestClient(app)
+        resp = test_client.get("/index-options")
+        assert resp.status_code == 401
+        setup_test_environment({"AUTH_ENABLED": "False"})
+
+    def test_stream_log_llm_error(self, client):
+        """Streaming endpoint returns 500 when LLM init fails."""
+        payload = {
+            "input": {
+                "question": "fail",
+                "chat_history": [],
+                "index_name": "TEST_INDEX",
+            }
+        }
+
+        with patch(
+            "app.chain.engine.ChatEngine._init_llm", side_effect=RuntimeError("boom")
+        ):
+            response = client.post("/chat/stream_log", json=payload)
+            assert response.status_code == 500
+
     def test_chat_stream_log_format(self, client):
         """Test /chat/stream_log returns proper SSE format."""
         payload = {
             "input": {
                 "question": "How to perform system maintenance?",
                 "chat_history": [],
-                "index_name": "TEST_INDEX"
+                "index_name": "TEST_INDEX",
             }
         }
-        
+
         with client.stream("POST", "/chat/stream_log", json=payload) as response:
             assert response.status_code == 200
             assert "text/event-stream" in response.headers.get("content-type", "")
-            
+
             # Collect streaming events
             events = []
             current_event = {}
-            
+
             for line in response.iter_lines():
                 line = line.decode() if isinstance(line, bytes) else line
-                
+
                 if line.startswith("event:"):
                     if current_event:
                         events.append(current_event)
@@ -222,24 +251,24 @@ class TestBackendE2EExample:
                     if current_event:
                         events.append(current_event)
                         current_event = {}
-            
+
             # Validate events
             assert len(events) > 0
-            
+
             # Should have data events and end event
             data_events = [e for e in events if e.get("event") == "data"]
             end_events = [e for e in events if e.get("event") == "end"]
-            
+
             assert len(data_events) > 0
             assert len(end_events) == 1
-            
+
             # Validate data event structure
             for event in data_events:
                 if event.get("data"):
                     # Should be valid JSON
                     data = json.loads(event["data"])
                     assert isinstance(data, dict)
-    
+
     def test_chat_batch_multiple_queries(self, client):
         """Test /chat/batch with multiple queries."""
         payload = {
@@ -248,56 +277,56 @@ class TestBackendE2EExample:
                     "question": "How to troubleshoot errors?",
                     "chat_history": [],
                     "index_name": "TEST_INDEX",
-                    "num_docs_retrieved": 2
+                    "num_docs_retrieved": 2,
                 },
                 {
                     "question": "What are maintenance procedures?",
                     "chat_history": [],
-                    "index_name": "TEST_INDEX", 
-                    "num_docs_retrieved": 2
-                }
+                    "index_name": "TEST_INDEX",
+                    "num_docs_retrieved": 2,
+                },
             ]
         }
-        
+
         response = client.post("/chat/batch", json=payload)
-        
+
         assert response.status_code == 200
         data = response.json()
-        
+
         # Validate batch response structure
         assert "output" in data
         assert "metadata" in data
-        
+
         # Should have responses for both inputs
         outputs = data["output"]
         assert len(outputs) == 2
-        
+
         # Each output should be a string
         for output in outputs:
             assert isinstance(output, str)
             assert len(output) > 0
-        
+
         # Validate metadata
         metadata = data["metadata"]
         assert "run_ids" in metadata
         assert len(metadata["run_ids"]) == 2
-    
+
     def test_api_schema_endpoints(self, client):
         """Test schema endpoints return valid schemas."""
         schema_endpoints = [
             "/chat/input_schema",
-            "/chat/output_schema", 
-            "/chat/config_schema"
+            "/chat/output_schema",
+            "/chat/config_schema",
         ]
-        
+
         for endpoint in schema_endpoints:
             response = client.get(endpoint)
             assert response.status_code == 200
-            
+
             # Should return valid JSON schema
             schema = response.json()
             assert isinstance(schema, dict)
-    
+
     def test_feedback_endpoint(self, client):
         """Test feedback endpoint accepts valid feedback."""
         # First, make a request to get a run_id
@@ -305,29 +334,25 @@ class TestBackendE2EExample:
             "input": {
                 "question": "Test query for feedback",
                 "chat_history": [],
-                "index_name": "TEST_INDEX"
+                "index_name": "TEST_INDEX",
             }
         }
-        
+
         chat_response = client.post("/chat/invoke", json=chat_payload)
         assert chat_response.status_code == 200
-        
+
         run_id = chat_response.json()["metadata"]["run_id"]
-        
+
         # Now submit feedback
-        feedback_payload = {
-            "run_id": run_id,
-            "score": 5,
-            "comment": "Test feedback"
-        }
-        
+        feedback_payload = {"run_id": run_id, "score": 5, "comment": "Test feedback"}
+
         feedback_response = client.post("/feedback", json=feedback_payload)
         assert feedback_response.status_code == 200
-        
+
         feedback_data = feedback_response.json()
         assert "result" in feedback_data
         assert "code" in feedback_data
-    
+
     def test_error_handling(self, client):
         """Test API error handling."""
         # Test with invalid payload
@@ -335,24 +360,27 @@ class TestBackendE2EExample:
             "input": {
                 # Missing required question field
                 "chat_history": [],
-                "index_name": "TEST_INDEX"
+                "index_name": "TEST_INDEX",
             }
         }
-        
+
         response = client.post("/chat/invoke", json=invalid_payload)
         assert response.status_code == 422  # Validation error
-        
+
         error_data = response.json()
         assert "detail" in error_data
-    
-    @pytest.mark.parametrize("query_type,expected_content", [
-        ("troubleshoot", "troubleshoot"),
-        ("maintenance", "maintenance"),
-        ("error handling", "error"),
-        ("part number PN-123", "part"),
-        ("what is system configuration", "what is"),
-        ("how to restart system", "how to")
-    ])
+
+    @pytest.mark.parametrize(
+        "query_type,expected_content",
+        [
+            ("troubleshoot", "troubleshoot"),
+            ("maintenance", "maintenance"),
+            ("error handling", "error"),
+            ("part number PN-123", "part"),
+            ("what is system configuration", "what is"),
+            ("how to restart system", "how to"),
+        ],
+    )
     def test_deterministic_responses(self, client, query_type, expected_content):
         """Test that fake LLM produces deterministic responses for different query types."""
         payload = {
@@ -360,27 +388,27 @@ class TestBackendE2EExample:
                 "question": query_type,
                 "chat_history": [],
                 "index_name": "TEST_INDEX",
-                "num_docs_retrieved": 3
+                "num_docs_retrieved": 3,
             }
         }
-        
+
         # Make the same request twice
         response1 = client.post("/chat/invoke", json=payload)
         response2 = client.post("/chat/invoke", json=payload)
-        
+
         assert response1.status_code == 200
         assert response2.status_code == 200
-        
+
         output1 = response1.json()["output"]
         output2 = response2.json()["output"]
-        
+
         # Responses should be identical (deterministic)
         assert output1 == output2
-        
+
         # Should contain expected content
         assert expected_content.lower() in output1.lower()
 
 
 if __name__ == "__main__":
     # Run tests directly
-    pytest.main([__file__, "-v"]) 
+    pytest.main([__file__, "-v"])

--- a/test_full_app/backend/test_config.py
+++ b/test_full_app/backend/test_config.py
@@ -1,0 +1,36 @@
+import os
+from typing import Dict
+
+
+_TEST_ENV: Dict[str, str] = {
+    "AUTH_ENABLED": "False",
+    "RAG_ON": "True",
+    "LLM_SERVICE": "azure",
+    "VECTOR_BACKEND": "test",
+    "LOG_LEVEL": "INFO",
+    "WEAVIATE_URL": "http://test:8080",
+    "WEAVIATE_API_KEY": "test-key",
+    "AZURE_OPENAI_API_VERSION": "2024-05-15",
+    "AZURE_OPENAI_DEPLOYMENT_NAME": "test-model",
+    "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com/",
+    "AZURE_OPENAI_API_KEY": "test-key",
+    "AZURE_SEARCH_ENDPOINT": "https://test.search.windows.net",
+    "AZURE_SEARCH_KEY": "test-key",
+    "PGVECTOR_URL": "postgresql://test:test@localhost/test",
+    "CORS_ORIGINS": '["http://localhost:3000"]',
+}
+
+
+def get_test_backend_config() -> Dict[str, str]:
+    """Return environment variables for backend testing."""
+    return _TEST_ENV.copy()
+
+
+def setup_test_environment(extra: Dict[str, str] | None = None) -> Dict[str, str]:
+    """Apply backend test environment variables."""
+    env = get_test_backend_config()
+    if extra:
+        env.update(extra)
+    for key, value in env.items():
+        os.environ[key] = value
+    return env

--- a/test_full_app/run_backend_e2e_demo.py
+++ b/test_full_app/run_backend_e2e_demo.py
@@ -16,6 +16,10 @@ import subprocess
 import argparse
 from pathlib import Path
 
+backend_dir = Path(__file__).parent / "backend"
+sys.path.insert(0, str(backend_dir))
+from test_config import get_test_backend_config
+
 
 # Legacy functions removed - functionality moved to separate scripts
 
@@ -24,12 +28,12 @@ def run_demo_script():
     """Run the standalone demo script."""
     current_dir = Path.cwd()
     demo_script = current_dir.parent / "test_full_app" / "demo_fake_components.py"
-    
+
     print("🎭 Running fake components demo...")
-    result = subprocess.run([
-        "poetry", "run", "python", str(demo_script)
-    ], cwd=current_dir)
-    
+    result = subprocess.run(
+        ["poetry", "run", "python", str(demo_script)], cwd=current_dir
+    )
+
     return result.returncode == 0
 
 
@@ -37,30 +41,41 @@ def run_test_script():
     """Run the standalone test script."""
     current_dir = Path.cwd()
     test_script = current_dir.parent / "test_full_app" / "run_backend_e2e_tests.py"
-    
+
     print("🧪 Running backend E2E tests...")
-    result = subprocess.run([
-        "poetry", "run", "python", str(test_script)
-    ], cwd=current_dir)
-    
+    result = subprocess.run(
+        ["poetry", "run", "python", str(test_script)], cwd=current_dir
+    )
+
+    if result.returncode != 0:
+        print("\n🛠 Environment Variables:")
+        for k, v in get_test_backend_config().items():
+            masked = v if "KEY" not in k else "***"
+            print(f"{k}={masked}")
+        print("🔎 Ensure LLM_SERVICE is set to 'azure' for patched LLM")
+
     return result.returncode == 0
 
 
 def main():
     """Main orchestrator script."""
-    parser = argparse.ArgumentParser(description="DRSearch backend testing orchestrator")
-    parser.add_argument("--with-demo", action="store_true", 
-                       help="Run component demo before tests")
-    parser.add_argument("--demo-only", action="store_true", 
-                       help="Run only the component demo")
-    
+    parser = argparse.ArgumentParser(
+        description="DRSearch backend testing orchestrator"
+    )
+    parser.add_argument(
+        "--with-demo", action="store_true", help="Run component demo before tests"
+    )
+    parser.add_argument(
+        "--demo-only", action="store_true", help="Run only the component demo"
+    )
+
     args = parser.parse_args()
-    
+
     print("🚀 DRSearch Backend Testing Orchestrator")
     print("=" * 50)
-    
+
     success = True
-    
+
     if args.demo_only:
         print("🎯 Running component demo only...")
         success = run_demo_script()
@@ -73,9 +88,11 @@ def main():
             print("\n❌ Tests failed")
             success = False
     else:
-        print("🎯 Running E2E tests only (use --with-demo to include component demo)...")
+        print(
+            "🎯 Running E2E tests only (use --with-demo to include component demo)..."
+        )
         success = run_test_script()
-    
+
     if success:
         print("\n🎉 All operations completed successfully!")
         print("\nAvailable scripts:")
@@ -88,4 +105,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/test_full_app/run_backend_e2e_tests.py
+++ b/test_full_app/run_backend_e2e_tests.py
@@ -2,7 +2,7 @@
 """
 Run backend end-to-end tests for DRSearch API with fake components.
 
-This script runs the actual backend API tests using deterministic fake 
+This script runs the actual backend API tests using deterministic fake
 components for reliable, reproducible testing.
 
 Usage:
@@ -16,65 +16,40 @@ import subprocess
 import argparse
 from pathlib import Path
 
+backend_dir = Path(__file__).parent / "backend"
+sys.path.insert(0, str(backend_dir))
 
-def setup_test_environment():
-    """Set up the complete test environment variables."""
-    test_env = {
-        "AUTH_ENABLED": "False",
-        "RAG_ON": "True",
-        "LLM_SERVICE": "fake",
-        "VECTOR_BACKEND": "test",
-        "LOG_LEVEL": "INFO",
-        # Required env vars (dummy values for testing)
-        "WEAVIATE_URL": "http://test:8080",
-        "WEAVIATE_API_KEY": "test-key",
-        "AZURE_OPENAI_API_VERSION": "2024-05-15",
-        "AZURE_OPENAI_DEPLOYMENT_NAME": "test-model",
-        "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com/",
-        "AZURE_OPENAI_API_KEY": "test-key",
-        "AZURE_SEARCH_ENDPOINT": "https://test.search.windows.net",
-        "AZURE_SEARCH_KEY": "test-key",
-        "PGVECTOR_URL": "postgresql://test:test@localhost/test",
-        "CORS_ORIGINS": '["http://localhost:3000"]',
-    }
-    
-    for key, value in test_env.items():
-        os.environ[key] = value
-    
-    print("✓ Test environment configured")
+from test_config import setup_test_environment, get_test_backend_config
 
 
 def run_pytest_test(test_file, description, env):
     """Run a specific pytest test file."""
     print(f"\n📋 {description}...")
-    
-    cmd = [
-        "poetry", "run", "pytest", 
-        str(test_file),
-        "-v",
-        "--tb=short",
-        "--no-header"
-    ]
-    
+
+    cmd = ["poetry", "run", "pytest", str(test_file), "-v", "--tb=short", "--no-header"]
+
     print(f"Running: {' '.join(cmd)}")
-    
+
     result = subprocess.run(
-        cmd,
-        cwd=Path.cwd(),
-        env=env,
-        capture_output=True,
-        text=True
+        cmd, cwd=Path.cwd(), env=env, capture_output=True, text=True
     )
-    
+
     # Print output
     if result.stdout:
         print(f"\n📋 {description} Output:")
         print(result.stdout)
-    
+
     if result.stderr:
         print(f"\n⚠️  {description} Errors:")
         print(result.stderr)
-    
+
+    if result.returncode != 0:
+        print("\n🛠 Environment Variables:")
+        for k, v in get_test_backend_config().items():
+            masked = v if "KEY" not in k else "***"
+            print(f"{k}={masked}")
+        print("🔎 Ensure LLM_SERVICE is set to 'azure' for patched LLM")
+
     return result
 
 
@@ -84,13 +59,15 @@ def run_simple_tests():
     if current_dir.name != "drsearch_backend":
         print("✗ This script should be run from the drsearch_backend directory")
         return False
-    
-    simple_test_file = current_dir.parent / "test_full_app" / "backend" / "test_backend_e2e_simple.py"
-    
+
+    simple_test_file = (
+        current_dir.parent / "test_full_app" / "backend" / "test_backend_e2e_simple.py"
+    )
+
     if not simple_test_file.exists():
         print(f"✗ Test file not found: {simple_test_file}")
         return False
-    
+
     # Set PYTHONPATH to include test components directory
     env = os.environ.copy()
     test_components_dir = current_dir.parent / "test_full_app" / "backend"
@@ -98,13 +75,11 @@ def run_simple_tests():
     if "PYTHONPATH" in env:
         python_path.append(env["PYTHONPATH"])
     env["PYTHONPATH"] = os.pathsep.join(python_path)
-    
+
     result = run_pytest_test(
-        simple_test_file, 
-        "Running Simplified Component Tests", 
-        env
+        simple_test_file, "Running Simplified Component Tests", env
     )
-    
+
     if result.returncode == 0:
         print("\n✅ Simplified component tests passed!")
         return True
@@ -116,12 +91,14 @@ def run_simple_tests():
 def run_full_api_tests():
     """Run the full backend API tests."""
     current_dir = Path.cwd()
-    full_test_file = current_dir.parent / "test_full_app" / "backend" / "test_backend_e2e_example.py"
-    
+    full_test_file = (
+        current_dir.parent / "test_full_app" / "backend" / "test_backend_e2e_example.py"
+    )
+
     if not full_test_file.exists():
         print(f"✗ Test file not found: {full_test_file}")
         return False
-    
+
     # Set PYTHONPATH to include test components directory
     env = os.environ.copy()
     test_components_dir = current_dir.parent / "test_full_app" / "backend"
@@ -129,15 +106,13 @@ def run_full_api_tests():
     if "PYTHONPATH" in env:
         python_path.append(env["PYTHONPATH"])
     env["PYTHONPATH"] = os.pathsep.join(python_path)
-    
-    result = run_pytest_test(
-        full_test_file, 
-        "Running Full Backend API Tests", 
-        env
-    )
-    
+
+    result = run_pytest_test(full_test_file, "Running Full Backend API Tests", env)
+
     if "SKIPPED" in result.stdout and "15 skipped" in result.stdout:
-        print("\n⚠️  Full backend API tests were skipped due to Pydantic compatibility issues.")
+        print(
+            "\n⚠️  Full backend API tests were skipped due to Pydantic compatibility issues."
+        )
         print("This is expected - the fake components work correctly.")
         print("To enable these tests, update the backend to use Pydantic v2 settings.")
         return True  # Consider skipped tests as success for now
@@ -152,23 +127,26 @@ def run_full_api_tests():
 def main():
     """Main test runner."""
     parser = argparse.ArgumentParser(description="Run DRSearch backend E2E tests")
-    parser.add_argument("--simple-only", action="store_true", 
-                       help="Run only simplified component tests")
-    parser.add_argument("--full-only", action="store_true", 
-                       help="Run only full backend API tests")
-    parser.add_argument("--verbose", "-v", action="store_true",
-                       help="Enable verbose output")
-    
+    parser.add_argument(
+        "--simple-only", action="store_true", help="Run only simplified component tests"
+    )
+    parser.add_argument(
+        "--full-only", action="store_true", help="Run only full backend API tests"
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose output"
+    )
+
     args = parser.parse_args()
-    
+
     print("🧪 DRSearch Backend E2E Tests")
     print("=" * 40)
-    
+
     # Setup environment
     setup_test_environment()
-    
+
     success = True
-    
+
     # Run tests based on arguments
     if args.simple_only:
         print("\n🎯 Running simplified component tests only...")
@@ -178,15 +156,15 @@ def main():
         success = run_full_api_tests()
     else:
         print("\n🎯 Running all backend E2E tests...")
-        
+
         # Run simplified tests first
         if not run_simple_tests():
             success = False
-        
+
         # Run full API tests
         if not run_full_api_tests():
             success = False
-    
+
     # Final results
     if success:
         print("\n🎉 All tests completed successfully!")
@@ -194,7 +172,7 @@ def main():
         print("• Fake components are working correctly")
         print("• Backend API integration is functional")
         print("• Tests provide deterministic, reliable results")
-        
+
         print("\n💡 Next steps:")
         print("• Integrate these tests into your CI/CD pipeline")
         print("• Extend fake_components.py for additional test scenarios")
@@ -205,9 +183,11 @@ def main():
         print("• Check that you're running from the drsearch_backend directory")
         print("• Verify that Poetry environment has all required dependencies")
         print("• Review test output above for specific error details")
-        print("• Run 'poetry run python ../test_full_app/demo_fake_components.py' to test components")
+        print(
+            "• Run 'poetry run python ../test_full_app/demo_fake_components.py' to test components"
+        )
         sys.exit(1)
 
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- add shared `test_config` helper for E2E tests
- update E2E runners to use `test_config` and print env info on failure
- adjust E2E example tests to use the shared setup
- add extra scenarios for index settings and failure cases

## Testing
- `poetry run pytest --cov=app --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_685e9900cf68832589e4d43e4dfd3ac9