### PR TITLE
feat: add langfuse tracing to answer chain

### DIFF
--- a/drsearch_backend/README.md
+++ b/drsearch_backend/README.md
@@ -14,6 +14,17 @@ poetry run pytest --cov=app --cov-report=term-missing -q
 
 ```
 
+## Langfuse Observability
+To enable request tracing with Langfuse, configure the following environment variables:
+
+```
+LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_PUBLIC_KEY=<your-public-key>
+LANGFUSE_SECRET_KEY=<your-secret-key>
+```
+
+The backend automatically attaches a Langfuse callback handler to its answer chain.
+
 
 
 ### Authentication — Detailed Technical Walk-through

--- a/drsearch_backend/app/chain/api.py
+++ b/drsearch_backend/app/chain/api.py
@@ -1,14 +1,17 @@
 # file: app/chain/api.py
+"""LangChain API helpers with optional Langfuse tracing."""
 
 from __future__ import annotations
 
 from typing import Dict, Tuple
 from langchain.schema.runnable import Runnable, RunnableLambda
+from langfuse.callback import CallbackHandler
 
 from app.chain.engine import ChatEngine
 from app.core.chain_config import _DEFAULT_INDEX, _NUMBER_OF_DOCS_RETRIEVED
 
 _engine_cache: Dict[Tuple[str, int], ChatEngine] = {}
+_langfuse_handler = CallbackHandler()
 
 
 def _engine_for(index_name: str, num_docs: int) -> ChatEngine:
@@ -16,16 +19,22 @@ def _engine_for(index_name: str, num_docs: int) -> ChatEngine:
     key = (index_name, num_docs)
     if key not in _engine_cache:
         # Update global setting before engine creation
-        from app.core import chain_config
+        from app.core import chain_config  # pylint: disable=import-outside-toplevel
 
-        chain_config._NUMBER_OF_DOCS_RETRIEVED = num_docs
+        chain_config._NUMBER_OF_DOCS_RETRIEVED = num_docs  # pylint: disable=protected-access
         _engine_cache[key] = ChatEngine(index_name)
     return _engine_cache[key]
 
 
-def get_answer_chain(index_name: str | None = None, num_docs: int = _NUMBER_OF_DOCS_RETRIEVED) -> Runnable:
+def get_answer_chain(
+    index_name: str | None = None,
+    num_docs: int = _NUMBER_OF_DOCS_RETRIEVED,
+) -> Runnable:
     """Return the langchain Runnable for the specified index (cached)."""
-    return _engine_for(index_name or _DEFAULT_INDEX, num_docs).answer_chain
+    chain = _engine_for(index_name or _DEFAULT_INDEX, num_docs).answer_chain
+    if hasattr(chain, "with_config"):
+        return chain.with_config(callbacks=[_langfuse_handler])
+    return chain
 
 
 answer_chain: Runnable = RunnableLambda(


### PR DESCRIPTION
## Summary
- instrument answer chain with a Langfuse callback handler
- document Langfuse environment variables for backend

## Testing
- `poetry run pylint app/chain/api.py`
- `poetry run pytest --cov=app --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9fbccdde0832585b7017b996037ac