### PR TITLE
feat: add langfuse tracing to answer chain

### DIFF
--- a/drsearch_backend/.example.env
+++ b/drsearch_backend/.example.env
@@ -6,6 +6,11 @@ NEXT_PUBLIC_AUTH_ENABLED=False
 #: Toggle RAG vs. plain-chatbot mode
 RAG_ON=FALSE
 
+LANGFUSE_ENABLED=False
+LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_PUBLIC_KEY=your-public-key
+LANGFUSE_SECRET_KEY=your-secret-key
+
 CORS_ORIGINS=["http://DRSearch_frontend:3000","http://localhost:3000"]
 # WHITELIST=["/chat/playground","/favicon.ico","/index-options"]
 

--- a/drsearch_backend/README.md
+++ b/drsearch_backend/README.md
@@ -14,6 +14,17 @@ poetry run pytest --cov=app --cov-report=term-missing -q
 
 ```
 
+## Langfuse Observability
+To enable request tracing with Langfuse, configure the following environment variables:
+
+```
+LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_PUBLIC_KEY=<your-public-key>
+LANGFUSE_SECRET_KEY=<your-secret-key>
+```
+
+The backend automatically attaches a Langfuse callback handler to its answer chain.
+
 
 
 ### Authentication — Detailed Technical Walk-through

--- a/drsearch_backend/README.md
+++ b/drsearch_backend/README.md
@@ -18,12 +18,15 @@ poetry run pytest --cov=app --cov-report=term-missing -q
 To enable request tracing with Langfuse, configure the following environment variables:
 
 ```
+LANGFUSE_ENABLED=True
 LANGFUSE_HOST=http://localhost:3000
 LANGFUSE_PUBLIC_KEY=<your-public-key>
 LANGFUSE_SECRET_KEY=<your-secret-key>
 ```
 
-The backend automatically attaches a Langfuse callback handler to its answer chain.
+Set `LANGFUSE_ENABLED` to `True` to enable tracing. When omitted or set to any other
+value, Langfuse is not used. The backend automatically attaches a Langfuse callback
+handler to its answer chain when enabled.
 
 
 

--- a/drsearch_backend/app/chain/api.py
+++ b/drsearch_backend/app/chain/api.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Sequence
+import json
+from langchain.schema import Document
 from langchain.schema.runnable import Runnable, RunnableLambda
 from langfuse.callback import CallbackHandler
 
@@ -13,11 +15,46 @@ from app.core.chain_config import _DEFAULT_INDEX, _NUMBER_OF_DOCS_RETRIEVED
 _engine_cache: Dict[Tuple[str, int], ChatEngine] = {}
 
 
+class _LangfuseCallbackHandler(CallbackHandler):  # pylint: disable=too-many-ancestors
+    """Langfuse handler that makes retriever outputs JSON serializable."""
+
+    @staticmethod
+    def _serialize_docs(documents: Sequence[Document]) -> list[dict]:
+        """Return docs with metadata values converted to strings when needed."""
+        def _safe(value: object) -> object:
+            try:
+                json.dumps(value)
+                return value
+            except TypeError:
+                return str(value)
+
+        return [
+            {
+                "page_content": doc.page_content,
+                "metadata": {k: _safe(v) for k, v in doc.metadata.items()},
+            }
+            for doc in documents
+        ]
+
+    def on_retriever_end(  # type: ignore[override]
+        self,
+        documents: Sequence[Document],
+        *,
+        run_id,
+        parent_run_id=None,
+        **kwargs,
+    ) -> None:
+        serializable = self._serialize_docs(documents)
+        super().on_retriever_end(
+            serializable, run_id=run_id, parent_run_id=parent_run_id, **kwargs
+        )
+
+
 def _new_langfuse_handler() -> CallbackHandler | None:
     """Create a new Langfuse handler if environment variables are set."""
     try:
-        return CallbackHandler()
-    except Exception:  # pragma: no cover - missing env vars
+        return _LangfuseCallbackHandler()
+    except Exception:  # pragma: no cover - missing env vars  # pylint: disable=broad-except
         return None
 
 

--- a/drsearch_backend/app/chain/api.py
+++ b/drsearch_backend/app/chain/api.py
@@ -1,9 +1,11 @@
 # file: app/chain/api.py
+"""LangChain API helpers with optional Langfuse tracing."""
 
 from __future__ import annotations
 
 from typing import Dict, Tuple
 from langchain.schema.runnable import Runnable, RunnableLambda
+from langfuse.callback import CallbackHandler
 
 from app.chain.engine import ChatEngine
 from app.core.chain_config import _DEFAULT_INDEX, _NUMBER_OF_DOCS_RETRIEVED
@@ -11,21 +13,38 @@ from app.core.chain_config import _DEFAULT_INDEX, _NUMBER_OF_DOCS_RETRIEVED
 _engine_cache: Dict[Tuple[str, int], ChatEngine] = {}
 
 
+def _new_langfuse_handler() -> CallbackHandler | None:
+    """Create a new Langfuse handler if environment variables are set."""
+    try:
+        return CallbackHandler()
+    except Exception:  # pragma: no cover - missing env vars
+        return None
+
+
 def _engine_for(index_name: str, num_docs: int) -> ChatEngine:
     """Retrieve or create a cached ChatEngine for the given index and k."""
     key = (index_name, num_docs)
     if key not in _engine_cache:
         # Update global setting before engine creation
-        from app.core import chain_config
+        from app.core import chain_config  # pylint: disable=import-outside-toplevel
 
-        chain_config._NUMBER_OF_DOCS_RETRIEVED = num_docs
+        chain_config._NUMBER_OF_DOCS_RETRIEVED = num_docs  # pylint: disable=protected-access
         _engine_cache[key] = ChatEngine(index_name)
     return _engine_cache[key]
 
 
-def get_answer_chain(index_name: str | None = None, num_docs: int = _NUMBER_OF_DOCS_RETRIEVED) -> Runnable:
+def get_answer_chain(
+    index_name: str | None = None,
+    num_docs: int = _NUMBER_OF_DOCS_RETRIEVED,
+    trace: bool = True,
+) -> Runnable:
     """Return the langchain Runnable for the specified index (cached)."""
-    return _engine_for(index_name or _DEFAULT_INDEX, num_docs).answer_chain
+    chain = _engine_for(index_name or _DEFAULT_INDEX, num_docs).answer_chain
+    if trace and hasattr(chain, "with_config"):
+        handler = _new_langfuse_handler()
+        if handler:
+            return chain.with_config(callbacks=[handler])
+    return chain
 
 
 answer_chain: Runnable = RunnableLambda(

--- a/drsearch_backend/app/chain/api.py
+++ b/drsearch_backend/app/chain/api.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 
 from typing import Dict, Tuple, Sequence
 import json
+import os
 from langchain.schema import Document
 from langchain.schema.runnable import Runnable, RunnableLambda
-from langfuse.callback import CallbackHandler
-
 from app.chain.engine import ChatEngine
 from app.core.chain_config import _DEFAULT_INDEX, _NUMBER_OF_DOCS_RETRIEVED
+
+LANGFUSE_ENABLED = os.getenv("LANGFUSE_ENABLED", "false").lower() == "true"
+
+if LANGFUSE_ENABLED:
+    from langfuse.callback import CallbackHandler
+else:  # pragma: no cover - executed only when Langfuse disabled
+    class CallbackHandler:  # pylint: disable=too-few-public-methods
+        """Placeholder handler when Langfuse is disabled."""
 
 _engine_cache: Dict[Tuple[str, int], ChatEngine] = {}
 
@@ -52,6 +59,8 @@ class _LangfuseCallbackHandler(CallbackHandler):  # pylint: disable=too-many-anc
 
 def _new_langfuse_handler() -> CallbackHandler | None:
     """Create a new Langfuse handler if environment variables are set."""
+    if not LANGFUSE_ENABLED:
+        return None
     try:
         return _LangfuseCallbackHandler()
     except Exception:  # pragma: no cover - missing env vars  # pylint: disable=broad-except

--- a/drsearch_backend/app/warmup.py
+++ b/drsearch_backend/app/warmup.py
@@ -16,7 +16,7 @@ async def warm_up_indexes() -> None:
     """Initialise all indexes so first user request is fast."""
     for index_name in INDEX_STATUS.keys():
         try:
-            engine = get_answer_chain(index_name)
+            engine = get_answer_chain(index_name, trace=False)
             await engine.ainvoke({"question": "warmup", "chat_history": []})
             INDEX_STATUS[index_name] = True
         except Exception as exc:  # noqa: BLE001

--- a/drsearch_backend/tests/test_langfuse_handler.py
+++ b/drsearch_backend/tests/test_langfuse_handler.py
@@ -1,0 +1,23 @@
+"""Tests for the Langfuse callback handler serialization helper."""
+
+from __future__ import annotations
+
+import json
+
+from langchain.schema import Document
+
+from app.chain.api import _LangfuseCallbackHandler
+
+
+def test_serialize_docs_handles_non_serializable_metadata() -> None:
+    """Ensure documents with complex metadata can be serialized to JSON."""
+    docs = [Document(page_content="foo", metadata={"a": object()})]
+
+    handler = _LangfuseCallbackHandler(
+        public_key="pk", secret_key="sk", host="http://localhost", enabled=False
+    )
+
+    serialized = handler._serialize_docs(docs)
+    # Should be convertible to JSON without raising
+    json.dumps(serialized)
+    assert serialized[0]["page_content"] == "foo"

--- a/drsearch_backend/tests/test_langfuse_handler.py
+++ b/drsearch_backend/tests/test_langfuse_handler.py
@@ -1,23 +1,38 @@
-"""Tests for the Langfuse callback handler serialization helper."""
+"""Tests for Langfuse callback handler and environment gating."""
 
 from __future__ import annotations
 
-import json
+import importlib
+import sys
 
 from langchain.schema import Document
 
-from app.chain.api import _LangfuseCallbackHandler
 
-
-def test_serialize_docs_handles_non_serializable_metadata() -> None:
+def test_serialize_docs_handles_non_serializable_metadata(monkeypatch) -> None:
     """Ensure documents with complex metadata can be serialized to JSON."""
-    docs = [Document(page_content="foo", metadata={"a": object()})]
+    monkeypatch.setenv("LANGFUSE_ENABLED", "true")
+    api = importlib.reload(importlib.import_module("app.chain.api"))
 
-    handler = _LangfuseCallbackHandler(
+    docs = [Document(page_content="foo", metadata={"a": object()})]
+    handler = api._LangfuseCallbackHandler(  # pylint: disable=protected-access
         public_key="pk", secret_key="sk", host="http://localhost", enabled=False
     )
 
-    serialized = handler._serialize_docs(docs)
+    serialized = handler._serialize_docs(docs)  # pylint: disable=protected-access
     # Should be convertible to JSON without raising
+    import json
+
     json.dumps(serialized)
     assert serialized[0]["page_content"] == "foo"
+
+
+def test_langfuse_disabled_skips_import(monkeypatch) -> None:
+    """Langfuse library is not imported when disabled."""
+    monkeypatch.setenv("LANGFUSE_ENABLED", "false")
+    sys.modules.pop("langfuse", None)
+    sys.modules.pop("langfuse.callback", None)
+    api = importlib.reload(importlib.import_module("app.chain.api"))
+
+    assert "langfuse" not in sys.modules
+    assert api._new_langfuse_handler() is None  # pylint: disable=protected-access
+

--- a/drsearch_backend/tests/test_warmup.py
+++ b/drsearch_backend/tests/test_warmup.py
@@ -16,7 +16,7 @@ def test_warm_up_success(monkeypatch):
         async def ainvoke(self, *_):
             return "ok"
 
-    monkeypatch.setattr(warmup, "get_answer_chain", lambda name: Dummy())
+    monkeypatch.setattr(warmup, "get_answer_chain", lambda name, **_: Dummy())
 
     asyncio.run(warmup.warm_up_indexes())
     assert warmup.INDEX_STATUS["idx"] is True
@@ -29,7 +29,7 @@ def test_warm_up_failure(monkeypatch):
         async def ainvoke(self, *_):
             raise ValueError("boom")
 
-    monkeypatch.setattr(warmup, "get_answer_chain", lambda name: Dummy())
+    monkeypatch.setattr(warmup, "get_answer_chain", lambda name, **_: Dummy())
 
     asyncio.run(warmup.warm_up_indexes())
     assert warmup.INDEX_STATUS["idx"] is False


### PR DESCRIPTION
## Summary
- instrument answer chain with a Langfuse callback handler
- document Langfuse environment variables for backend
- ensure each request gets a fresh Langfuse trace and skip tracing during index warm-up

## Testing
- `poetry run pylint app/chain/api.py app/warmup.py`
- `poetry run pytest --cov=app --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9fbccdde0832585b7017b996037ac