### PR TITLE
Add robust acronym cleanup filters

### DIFF
--- a/drsearch_backend/app/index_options.py
+++ b/drsearch_backend/app/index_options.py
@@ -26,6 +26,36 @@ try:
 except Exception:  # pragma: no cover - missing/invalid file
     _IGNORED_ACRONYM_KEYS = set()
 
+# ---------------------------------------------------------------------------
+# Acronym helpers
+
+
+def _is_valid_acronym(key: str, value: str) -> bool:
+    """Return True if the acronym key/value pair should be kept."""
+
+    key_clean = key.strip()
+    if not key_clean or not value:
+        return False
+    if key_clean.upper() in _IGNORED_ACRONYM_KEYS:
+        return False
+    # Remove short keys (2 or fewer characters)
+    if len(key_clean) <= 2:
+        return False
+    # Remove values with disallowed punctuation
+    if any(char in value for char in ".(),[]"):
+        return False
+    # Remove excessively long values compared to key length
+    word_count = len(value.split())
+    if word_count - len(key_clean) >= 3:
+        return False
+    # Remove keys with more lowercase than uppercase letters
+    upper = sum(c.isupper() for c in key_clean)
+    lower = sum(c.islower() for c in key_clean)
+    if lower > upper:
+        return False
+    return True
+
+
 # Base index option definitions without acronym data
 _BASE_INDEX_OPTIONS = [
     {
@@ -101,11 +131,8 @@ def _fetch_acronyms(index_name: str) -> Dict[str, str]:
         keys = meta.get("acronym_keys") or []
         values = meta.get("acronym_values") or []
         for k, v in zip(keys, values):
-            if not k or not v:
-                continue
-            if k.upper() in _IGNORED_ACRONYM_KEYS:
-                continue
-            acronyms[k] = v
+            if _is_valid_acronym(k, v):
+                acronyms[k] = v
     return acronyms
 
 

--- a/drsearch_backend/tests/test_index_options.py
+++ b/drsearch_backend/tests/test_index_options.py
@@ -41,19 +41,79 @@ def _run_fetch(monkeypatch, rows):
 
 def test_fetch_acronyms_filters_empty_and_none(monkeypatch):
     rows = [
-        {"cmetadata": {"acronym_keys": ["A", "", "B"], "acronym_values": ["Alpha", "foo", ""]}}
+        {
+            "cmetadata": {
+                "acronym_keys": ["ABC", "", "DEF"],
+                "acronym_values": ["Alpha", "foo", ""],
+            }
+        }
     ]
-    assert _run_fetch(monkeypatch, rows) == {"A": "Alpha"}
+    assert _run_fetch(monkeypatch, rows) == {"ABC": "Alpha"}
 
 
 def test_fetch_acronyms_respects_ignore_list_case_insensitive(monkeypatch):
     rows = [
         {
             "cmetadata": {
-                "acronym_keys": ["HR", "IT", "ip"],
-                "acronym_values": ["Human Resources", "Information Tech", "internet protocol"],
+                "acronym_keys": ["HRS", "IT", "ip"],
+                "acronym_values": [
+                    "Human Resources",
+                    "Information Tech",
+                    "internet protocol",
+                ],
             }
         }
     ]
     result = _run_fetch(monkeypatch, rows)
-    assert result == {"HR": "Human Resources"}
+    assert result == {"HRS": "Human Resources"}
+
+
+def test_fetch_acronyms_excludes_short_keys(monkeypatch):
+    rows = [
+        {
+            "cmetadata": {
+                "acronym_keys": ["AB", "ABC"],
+                "acronym_values": ["Alpha Beta", "Gamma"],
+            }
+        }
+    ]
+    assert _run_fetch(monkeypatch, rows) == {"ABC": "Gamma"}
+
+
+def test_fetch_acronyms_excludes_long_values(monkeypatch):
+    rows = [
+        {
+            "cmetadata": {
+                "acronym_keys": ["ABC", "LONG"],
+                "acronym_values": [
+                    "one two three four five six",
+                    "word word",
+                ],
+            }
+        }
+    ]
+    assert _run_fetch(monkeypatch, rows) == {"LONG": "word word"}
+
+
+def test_fetch_acronyms_excludes_values_with_punctuation(monkeypatch):
+    rows = [
+        {
+            "cmetadata": {
+                "acronym_keys": ["ABC", "DEF"],
+                "acronym_values": ["has, comma", "clean value"],
+            }
+        }
+    ]
+    assert _run_fetch(monkeypatch, rows) == {"DEF": "clean value"}
+
+
+def test_fetch_acronyms_excludes_keys_with_more_lowercase(monkeypatch):
+    rows = [
+        {
+            "cmetadata": {
+                "acronym_keys": ["eMail", "ABC"],
+                "acronym_values": ["electronic mail", "Just example"],
+            }
+        }
+    ]
+    assert _run_fetch(monkeypatch, rows) == {"ABC": "Just example"}


### PR DESCRIPTION
## Summary
- reject acronyms with short keys, overly long values, disallowed punctuation or lowercase-heavy keys
- test acronym cleanup for short keys, verbose values, punctuation and lowercase-heavy keys

## Testing
- `poetry run pylint app/index_options.py tests/test_index_options.py`
- `poetry run pytest --cov=app --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1912688948325ac6004eef889748c