### PR TITLE
Show only cited documents in source list

### DIFF
--- a/drsearch_frontend/app/components/ChatMessageBubble.tsx
+++ b/drsearch_frontend/app/components/ChatMessageBubble.tsx
@@ -16,10 +16,6 @@ import {
   Button,
   Divider,
   Spacer,
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-  PopoverBody,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -96,6 +92,46 @@ export const filterSources = (sources: Source[]) => {
   return { filtered, indexMap };
 };
 
+export const filterSourcesByCitations = (
+  content: string,
+  filteredSources: Source[],
+  sourceIndexMap: Map<number, number>,
+) => {
+  const citationRegex = /\[\s*[\^\$]?(\d+)[\^\$]?\s*\]/g;
+  const matches = Array.from(content.matchAll(citationRegex));
+  const citedOriginal = new Set<number>();
+  matches.forEach((match) => {
+    citedOriginal.add(parseInt(match[1], 10));
+  });
+
+  const usedDedup = new Set<number>();
+  citedOriginal.forEach((orig) => {
+    const dedup = sourceIndexMap.get(orig);
+    if (dedup !== undefined) {
+      usedDedup.add(dedup);
+    }
+  });
+
+  const remap = new Map<number, number>();
+  const newFiltered: Source[] = [];
+  filteredSources.forEach((src, idx) => {
+    if (usedDedup.has(idx)) {
+      remap.set(idx, newFiltered.length);
+      newFiltered.push(src);
+    }
+  });
+
+  const newIndexMap = new Map<number, number>();
+  sourceIndexMap.forEach((dedupIdx, origIdx) => {
+    const newIdx = remap.get(dedupIdx);
+    if (newIdx !== undefined) {
+      newIndexMap.set(origIdx, newIdx);
+    }
+  });
+
+  return { filteredSources: newFiltered, indexMap: newIndexMap };
+};
+
 export const createAnswerElements = (
   content: string,
   filteredSources: Source[],
@@ -118,7 +154,8 @@ export const createAnswerElements = (
 
   matches.forEach((match) => {
     const sourceNum = parseInt(match[1], 10);
-    const resolvedNum = sourceIndexMap.get(sourceNum) ?? 10;
+    const resolvedNum =
+      sourceIndexMap.get(sourceNum) ?? filteredSources.length - 1;
     if (match.index !== null && resolvedNum < filteredSources.length) {
       elements.push(
         <span
@@ -288,8 +325,10 @@ export function ChatMessageBubble(props: {
   __TEST__.viewTrace = viewTrace;
 
   const sources = props.message.sources ?? [];
-  const { filtered: filteredSources, indexMap: sourceIndexMap } =
+  const { filtered: dedupedSources, indexMap: initialIndexMap } =
     filterSources(sources);
+  const { filteredSources, indexMap: sourceIndexMap } =
+    filterSourcesByCitations(content, dedupedSources, initialIndexMap);
 
   // Use an array of highlighted states as a state since React
   // complains when creating states in a loop
@@ -349,39 +388,30 @@ export function ChatMessageBubble(props: {
         <>
           <Flex direction={"column"} width={"100%"}>
             <VStack spacing={"5px"} align={"start"} width={"100%"}>
-              <Popover trigger="hover" placement="bottom-start" isLazy>
-                <PopoverTrigger>
-                  <Heading
-                    fontSize="lg"
-                    fontWeight={"medium"}
-                    mb={1}
-                    color={"blue.300"}
-                    paddingBottom={"10px"}
-                    cursor="pointer"
-                  >
-                    View Sources
-                  </Heading>
-                </PopoverTrigger>
-                <PopoverContent bg="rgb(45,52,62)" border="none" width="auto">
-                  <PopoverBody>
-                    <SourceList
-                      sources={filteredSources}
-                      highlightedStates={highlighedSourceLinkStates}
-                      onMouseEnter={(index) => {
-                        setHighlightedSourceLinkStates(
-                          filteredSources.map((_, i) => i === index),
-                        );
-                      }}
-                      onMouseLeave={() =>
-                        setHighlightedSourceLinkStates(
-                          filteredSources.map(() => false),
-                        )
-                      }
-                      runId={runId}
-                    />
-                  </PopoverBody>
-                </PopoverContent>
-              </Popover>
+              <Heading
+                fontSize="lg"
+                fontWeight={"medium"}
+                mb={1}
+                color={"blue.300"}
+                paddingBottom={"10px"}
+              >
+                View Sources
+              </Heading>
+              <SourceList
+                sources={filteredSources}
+                highlightedStates={highlighedSourceLinkStates}
+                onMouseEnter={(index) => {
+                  setHighlightedSourceLinkStates(
+                    filteredSources.map((_, i) => i === index),
+                  );
+                }}
+                onMouseLeave={() =>
+                  setHighlightedSourceLinkStates(
+                    filteredSources.map(() => false),
+                  )
+                }
+                runId={runId}
+              />
             </VStack>
           </Flex>
 

--- a/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
@@ -261,6 +261,27 @@ describe("ChatMessageBubble component", () => {
       <ChatMessageBubble
         message={{
           id: "7",
+          content: "answer [0]",
+          role: "assistant",
+          runId: "r",
+          sources: [{ url: "u", title: "Title" }],
+        }}
+        isMostRecent
+        messageCompleted
+        conversation={[]}
+      />,
+    );
+    screen.getByText("View Sources");
+    const link = screen.getByText("Title");
+    fireEvent.mouseEnter(link);
+    fireEvent.mouseLeave(link);
+  });
+
+  test("does not show sources without citations", () => {
+    renderWithProviders(
+      <ChatMessageBubble
+        message={{
+          id: "8",
           content: "answer",
           role: "assistant",
           runId: "r",
@@ -271,11 +292,7 @@ describe("ChatMessageBubble component", () => {
         conversation={[]}
       />,
     );
-    const heading = screen.getByText("View Sources");
-    fireEvent.mouseEnter(heading);
-    const link = await screen.findByText("Title");
-    fireEvent.mouseEnter(link);
-    fireEvent.mouseLeave(link);
+    expect(screen.queryByText("View Sources")).not.toBeInTheDocument();
   });
 
   test("citation fallback uses last source", () => {

--- a/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
@@ -197,8 +197,20 @@ test("changing index resets chat", async () => {
 
 test("index change clears messages", async () => {
   (fetchIndexOptions as jest.Mock).mockResolvedValue([
-    { name: "a", display_name: "A", example_questions: [], initialized: true, acronyms: {} },
-    { name: "b", display_name: "B", example_questions: [], initialized: true, acronyms: {} },
+    {
+      name: "a",
+      display_name: "A",
+      example_questions: [],
+      initialized: true,
+      acronyms: {},
+    },
+    {
+      name: "b",
+      display_name: "B",
+      example_questions: [],
+      initialized: true,
+      acronyms: {},
+    },
   ]);
   (fetchEventSource as jest.Mock).mockImplementation(async (_url, opts) => {
     opts.onmessage?.({
@@ -329,7 +341,7 @@ test("renders highlighted markdown and updates message", async () => {
           {
             op: "add",
             path: "/streamed_output",
-            value: ["response"],
+            value: ["response [0]"],
           },
           {
             op: "add",
@@ -364,6 +376,7 @@ test("renders highlighted markdown and updates message", async () => {
 
   expect(highlightSpy).toHaveBeenCalled();
   expect(screen.getByText("View Sources")).toBeInTheDocument();
+  expect(screen.getByText("f")).toBeInTheDocument();
 });
 
 test("enter vs shift+enter", async () => {


### PR DESCRIPTION
## Summary
- Only display documents in source list when referenced by inline citations
- Reveal source links without hover and remove popover wrapper
- Add tests for filtering uncited documents and updated display logic

## Testing
- `yarn lint`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c1c2533e3483259469c9dbaf640ead