### PR TITLE
Add feedback-only submission button

### DIFF
--- a/drsearch_backend/app/api/v1/routes.py
+++ b/drsearch_backend/app/api/v1/routes.py
@@ -87,7 +87,10 @@ def build_router(settings: Settings) -> APIRouter:  # noqa: D401 – factory
     async def create_feedback(body: Feedback) -> StandardResponse:  # noqa: D401
         # TODO: integrate LangSmith client when available
         data = body.dict()
-        data["thumb"] = "up" if body.score and float(body.score) > 0 else "down"
+        if body.score is None:
+            data["thumb"] = "feedback_only"
+        else:
+            data["thumb"] = "up" if float(body.score) > 0 else "down"
         _store_feedback(data)
         logger.info("Feedback stored")
         return StandardResponse(result="posted feedback successfully")

--- a/drsearch_backend/tests/test_api_routes.py
+++ b/drsearch_backend/tests/test_api_routes.py
@@ -68,6 +68,29 @@ def test_feedback_logged(tmp_path, monkeypatch):
     assert not any(json.loads(l).get("message") == "feedback" for l in general_lines)
 
 
+def test_feedback_only_logged(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("LOG_OUTPUT_MODE", "local")
+    from app import core as core_pkg
+
+    importlib.reload(core_pkg.logging)
+    from app import create_app
+
+    client = TestClient(create_app())
+    body = {
+        "run_id": "33333333-3333-3333-3333-333333333333",
+        "key": "user_score",
+        "comment": "only feedback",
+    }
+    assert client.post("/feedback", json=body).status_code == 200
+    core_pkg.logging.shutdown_logging()
+    lines = [
+        json.loads(l) for l in (tmp_path / "feedback.jsonl").read_text().splitlines()
+    ]
+    entry = next(item for item in lines if item.get("message") == "feedback")
+    assert entry["thumb"] == "feedback_only"
+
+
 def test_get_trace_not_implemented(fastapi_client: TestClient):
     r = fastapi_client.post(
         "/get_trace", json={"run_id": "11111111-1111-1111-1111-111111111111"}

--- a/drsearch_frontend/app/components/ChatMessageBubble.tsx
+++ b/drsearch_frontend/app/components/ChatMessageBubble.tsx
@@ -26,16 +26,14 @@ import {
   Textarea,
 } from "@chakra-ui/react";
 import { sendFeedback } from "../utils/sendFeedback";
-import { apiBaseUrl } from "../utils/constants";
 import { InlineCitation } from "./InlineCitation";
 import DOMPurify from "dompurify";
 
 export const __TEST__ = {
   sendUserFeedback: null as
-    | ((score: number, key: string) => Promise<void>)
+    | ((score: number | null, key: string) => Promise<void>)
     | null,
   animateButton: null as ((buttonId: string) => void) | null,
-  viewTrace: null as (() => Promise<void>) | null,
   setComment: null as ((c: string) => void) | null,
   comment: "",
 };
@@ -55,7 +53,7 @@ export type Feedback = {
   feedback_id: string;
   run_id: string;
   key: string;
-  score: number;
+  score: number | null;
   comment?: string;
 };
 
@@ -213,7 +211,6 @@ export function ChatMessageBubble(props: {
   console.log("Rendering ChatMessageBubble with props:", props);
   const isUser = role === "user";
   const [isLoading, setIsLoading] = useState(false);
-  const [traceIsLoading, setTraceIsLoading] = useState(false);
   const [feedback, setFeedback] = useState<Feedback | null>(null);
   const [comment, setComment] = useState("");
   __TEST__.setComment = setComment;
@@ -242,7 +239,7 @@ export function ChatMessageBubble(props: {
     };
   };
 
-  const sendUserFeedback = async (score: number, key: string) => {
+  const sendUserFeedback = async (score: number | null, key: string) => {
     console.log(`Sending user feedback with score: ${score}, key: ${key}`);
     let run_id = runId;
     if (run_id === undefined) {
@@ -258,7 +255,7 @@ export function ChatMessageBubble(props: {
     setIsLoading(true);
     try {
       const data = await sendFeedback({
-        score,
+        score: score ?? undefined,
         runId: run_id,
         key,
         feedbackId: feedback?.feedback_id,
@@ -273,7 +270,9 @@ export function ChatMessageBubble(props: {
       });
       if (data.code === 200) {
         setFeedback({ run_id, score, key, feedback_id: data.feedbackId });
-        score === 1 ? animateButton("upButton") : animateButton("downButton");
+        if (score !== null) {
+          score === 1 ? animateButton("upButton") : animateButton("downButton");
+        }
         if (comment) {
           /* istanbul ignore next */
           setComment("");
@@ -289,40 +288,6 @@ export function ChatMessageBubble(props: {
     setIsLoading(false);
   };
   __TEST__.sendUserFeedback = sendUserFeedback;
-
-  const viewTrace = async () => {
-    console.log("Viewing trace for run ID:", runId);
-    try {
-      setTraceIsLoading(true);
-      const response = await fetch(apiBaseUrl + "/get_trace", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`, // Include access token in API request
-        },
-        body: JSON.stringify({
-          run_id: runId,
-        }),
-      });
-
-      const data = await response.json();
-
-      if (data.code === 400) {
-        toast.error("Unable to view trace");
-        throw new Error("Unable to view trace");
-      } else {
-        const url = data.replace(/['"]+/g, "");
-        window.open(url, "_blank");
-        console.log("Trace URL opened:", url);
-        setTraceIsLoading(false);
-      }
-    } catch (e: any) {
-      console.error("Error viewing trace:", e);
-      setTraceIsLoading(false);
-      toast.error(e.message);
-    }
-  };
-  __TEST__.viewTrace = viewTrace;
 
   const sources = props.message.sources ?? [];
   const { filtered: dedupedSources, indexMap: initialIndexMap } =
@@ -478,16 +443,20 @@ export function ChatMessageBubble(props: {
               <Button
                 size="sm"
                 variant="outline" /* istanbul ignore next */
-                colorScheme={runId === null ? "black" : "black"}
-                onClick={(e) => {
-                  e.preventDefault();
-                  viewTrace();
+                colorScheme={feedback === null ? "blue" : "gray"}
+                onClick={() => {
+                  if (feedback === null && props.message.runId) {
+                    setPendingScore(null);
+                    setIsModalOpen(true);
+                    setFeedbackColor("border-4 border-blue-300");
+                  } else {
+                    /* istanbul ignore next */
+                    toast.error("You have already provided your feedback.");
+                  }
                 }}
-                isLoading={traceIsLoading}
-                loadingText="🔄"
                 color="black"
               >
-                🚀🚀 View trace
+                Submit Feedback
               </Button>
             </HStack>
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
@@ -507,13 +476,10 @@ export function ChatMessageBubble(props: {
                     colorScheme="blue"
                     mr={3}
                     onClick={async () => {
-                      if (pendingScore !== null) {
-                        await sendUserFeedback(pendingScore, "user_score");
-                        animateButton(
-                          pendingScore === 1 ? "upButton" : "downButton",
-                        );
-                        setIsModalOpen(false);
-                      }
+                      const key =
+                        pendingScore === null ? "feedback_only" : "user_score";
+                      await sendUserFeedback(pendingScore, key);
+                      setIsModalOpen(false);
                     }}
                     isLoading={isLoading}
                   >

--- a/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatMessageBubble.test.tsx
@@ -210,11 +210,11 @@ describe("ChatMessageBubble component", () => {
     await waitFor(() => expect(sendFeedback).toHaveBeenCalledTimes(1));
   });
 
-  test("view trace button opens url", async () => {
-    (global as any).fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve('"http://x"') }),
-    );
-    const open = (window.open = jest.fn());
+  test("submit feedback button sends feedback without score", async () => {
+    (sendFeedback as jest.Mock).mockResolvedValue({
+      code: 200,
+      feedbackId: "fbo",
+    });
     renderWithProviders(
       <ChatMessageBubble
         message={{
@@ -229,31 +229,18 @@ describe("ChatMessageBubble component", () => {
         conversation={[]}
       />,
     );
-    fireEvent.click(screen.getByText(/view trace/i));
-    await waitFor(() => expect(open).toHaveBeenCalled());
-  });
-
-  test("view trace shows error", async () => {
-    (global as any).fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve({ code: 400 }) }),
-    );
-    const open = (window.open = jest.fn());
-    renderWithProviders(
-      <ChatMessageBubble
-        message={{
-          id: "6",
-          content: "answer",
-          role: "assistant",
+    fireEvent.click(screen.getByText(/submit feedback/i));
+    fireEvent.click(screen.getByText("Send"));
+    await waitFor(() =>
+      expect(sendFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          score: undefined,
           runId: "r",
-          sources: [],
-        }}
-        isMostRecent
-        messageCompleted
-        conversation={[]}
-      />,
+          key: "feedback_only",
+          accessToken: "t",
+        }),
+      ),
     );
-    fireEvent.click(screen.getByText(/view trace/i));
-    await waitFor(() => expect(open).not.toHaveBeenCalled());
   });
 
   test("source list hover highlights", async () => {
@@ -357,15 +344,12 @@ describe("ChatMessageBubble component", () => {
     expect(emojisplosion).not.toHaveBeenCalled();
   });
 
-  test("post feedback clicks and trace error flow", async () => {
+  test("post feedback clicks show error", async () => {
     jest.useRealTimers();
     (sendFeedback as jest.Mock).mockResolvedValue({
       code: 200,
       feedbackId: "1",
     });
-    (global as any).fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve({ code: 400 }) }),
-    );
     const toast = require("react-toastify").toast;
     const err = jest.spyOn(toast, "error").mockImplementation(() => {});
     renderWithProviders(
@@ -391,9 +375,9 @@ describe("ChatMessageBubble component", () => {
     expect(err).toHaveBeenCalledWith(
       "You have already provided your feedback.",
     );
-    await (__TEST__.viewTrace as any)();
-    await waitFor(() =>
-      expect(err).toHaveBeenCalledWith("Unable to view trace"),
+    fireEvent.click(screen.getByText(/submit feedback/i));
+    expect(err).toHaveBeenCalledWith(
+      "You have already provided your feedback.",
     );
     err.mockRestore();
   });


### PR DESCRIPTION
## Summary
- replace View Trace with Submit Feedback button and allow feedback-only submissions
- log `thumb: feedback_only` when score is omitted
- test feedback-only flow on frontend and backend

## Testing
- `yarn lint`
- `yarn test --coverage`
- `poetry run pytest --cov=app --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f2a16a7c8325ad5d89555dd8de17