### PR TITLE
Replace custom AcronymTextarea with native autosizing textarea

### DIFF
--- a/drsearch_frontend/app/components/AutoResizeTextarea.tsx
+++ b/drsearch_frontend/app/components/AutoResizeTextarea.tsx
@@ -1,6 +1,4 @@
-// app\components\AcronymTextarea.tsx
-
-import React, { useMemo, useRef, useState, useImperativeHandle } from "react";
+import React, { useImperativeHandle, useRef, useState } from "react";
 import { Textarea, TextareaProps } from "@chakra-ui/react";
 import ResizeTextarea from "react-textarea-autosize";
 import { expandLastAcronym } from "../utils/acronyms";
@@ -12,34 +10,19 @@ interface Replacement {
   end: number;
 }
 
-interface AcronymTextareaProps extends TextareaProps {
+interface AutoResizeTextareaProps extends TextareaProps {
   value: string;
   onChange: (val: string) => void;
   acronymMap: Record<string, string>;
 }
 
-export const AcronymTextarea = React.forwardRef<
+export const AutoResizeTextarea = React.forwardRef<
   HTMLTextAreaElement,
-  AcronymTextareaProps
+  AutoResizeTextareaProps
 >(({ value, onChange, acronymMap, onKeyDown, ...props }, ref) => {
   const innerRef = useRef<HTMLTextAreaElement | null>(null);
   useImperativeHandle(ref, () => innerRef.current as HTMLTextAreaElement);
   const [replacements, setReplacements] = useState<Replacement[]>([]);
-
-  const renderWithHighlights = useMemo(() => {
-    let result = "";
-    let lastIndex = 0;
-    const text = value;
-    replacements.forEach((r) => {
-      result += escapeHtml(text.slice(lastIndex, r.start));
-      result += `<span class="acronym-replacement">${escapeHtml(
-        text.slice(r.start, r.end),
-      )}</span>`;
-      lastIndex = r.end;
-    });
-    result += escapeHtml(text.slice(lastIndex));
-    return result;
-  }, [value, replacements]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const val = e.target.value;
@@ -58,6 +41,13 @@ export const AcronymTextarea = React.forwardRef<
       setReplacements((rs) => [...rs, { acronym, expansion, start, end }]);
       e.target.value = text;
       onChange(text);
+      requestAnimationFrame(() => {
+        innerRef.current?.setSelectionRange(start, end);
+        requestAnimationFrame(() => {
+          const pos = innerRef.current?.value.length ?? 0;
+          innerRef.current?.setSelectionRange(pos, pos);
+        });
+      });
     } else {
       onChange(val);
     }
@@ -83,16 +73,12 @@ export const AcronymTextarea = React.forwardRef<
             .filter((_, i) => i !== idx)
             .map((r) =>
               r.start > rep.start
-                ? {
-                    ...r,
-                    start: r.start - diff,
-                    end: r.end - diff,
-                  }
+                ? { ...r, start: r.start - diff, end: r.end - diff }
                 : r,
             ),
         );
-        el.selectionStart = el.selectionEnd =
-          rep.start + rep.acronym.length + 1;
+        const caret = rep.start + rep.acronym.length + 1;
+        el.setSelectionRange(caret, caret);
         return;
       }
     }
@@ -100,49 +86,15 @@ export const AcronymTextarea = React.forwardRef<
   };
 
   return (
-    <div style={{ position: "relative", width: "100%" }}>
-      <div
-        data-testid="acronym-overlay"
-        aria-hidden="true"
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: "100%",
-          whiteSpace: "pre-wrap",
-          wordBreak: "break-word",
-          color: "black",
-          pointerEvents: "none",
-          zIndex: 0,
-        }}
-        dangerouslySetInnerHTML={{ __html: renderWithHighlights }}
-      />
-      <Textarea
-        as={ResizeTextarea}
-        ref={innerRef}
-        value={value}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        style={{
-          position: "relative",
-          background: "transparent",
-          color: "transparent",
-          caretColor: "black",
-          zIndex: 1,
-        }}
-        {...props}
-      />
-    </div>
+    <Textarea
+      as={ResizeTextarea}
+      ref={innerRef}
+      value={value}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      {...props}
+    />
   );
 });
 
-AcronymTextarea.displayName = "AcronymTextarea";
-
-function escapeHtml(text: string) {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
+AutoResizeTextarea.displayName = "AutoResizeTextarea";

--- a/drsearch_frontend/app/components/ChatWindow.tsx
+++ b/drsearch_frontend/app/components/ChatWindow.tsx
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 import { useSession } from "next-auth/react";
 import { EmptyState } from "../components/EmptyState";
 import { ChatMessageBubble, Message } from "../components/ChatMessageBubble";
-import { AcronymTextarea } from "./AcronymTextarea";
+import { AutoResizeTextarea } from "./AutoResizeTextarea";
 import { marked, Renderer } from "marked";
 import hljs from "highlight.js";
 import "highlight.js/styles/gradient-dark.css";
@@ -347,7 +347,7 @@ export function ChatWindow(props: {
 
       {/* input + send */}
       <InputGroup size="md" alignItems="center">
-        <AcronymTextarea
+        <AutoResizeTextarea
           ref={inputRef}
           value={input}
           maxRows={20}

--- a/drsearch_frontend/app/components/__tests__/AutoResizeTextarea.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/AutoResizeTextarea.test.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { AcronymTextarea } from "../AcronymTextarea";
+import { AutoResizeTextarea } from "../AutoResizeTextarea";
 
 function Wrapper() {
   const [val, setVal] = React.useState("");
   return (
-    <AcronymTextarea
+    <AutoResizeTextarea
       value={val}
       onChange={setVal}
       acronymMap={{ TLA: "three letter acronym" }}
@@ -15,24 +15,23 @@ function Wrapper() {
   );
 }
 
-test("acronym expansion is styled and persists until removed", async () => {
+test("acronym expansion is applied and can be removed", async () => {
   const user = userEvent.setup();
   render(<Wrapper />);
   const textarea = screen.getByPlaceholderText("test");
   await user.type(textarea, "This is a TLA ");
-  const overlay = screen.getByTestId("acronym-overlay");
-  expect(overlay.innerHTML).toContain(
-    '<span class="acronym-replacement">three letter acronym</span>',
+  expect((textarea as HTMLTextAreaElement).value).toBe(
+    "This is a three letter acronym ",
   );
+  await new Promise((r) => setTimeout(r, 50));
   await user.type(textarea, "test");
-  expect(overlay.innerHTML).toContain(
-    '<span class="acronym-replacement">three letter acronym</span>',
+  expect((textarea as HTMLTextAreaElement).value).toBe(
+    "This is a three letter acronym test",
   );
   await user.type(textarea, "{backspace}{backspace}{backspace}{backspace}");
-  expect(overlay.innerHTML).toContain(
-    '<span class="acronym-replacement">three letter acronym</span>',
+  expect((textarea as HTMLTextAreaElement).value).toBe(
+    "This is a three letter acronym ",
   );
   await user.type(textarea, "{backspace}");
-  expect(overlay.innerHTML).not.toContain("acronym-replacement");
-  expect((textarea as HTMLTextAreaElement).value).toContain("TLA ");
+  expect((textarea as HTMLTextAreaElement).value).toBe("This is a TLA ");
 });

--- a/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
+++ b/drsearch_frontend/app/components/__tests__/ChatWindow.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   act,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { SessionProvider, useSession } from "next-auth/react";
 import { ChatWindow } from "../ChatWindow";
 import { fetchIndexOptions } from "../../utils/fetchIndexOptions";
@@ -265,9 +266,8 @@ test("expands acronyms and restores on backspace", async () => {
   fireEvent.change(box, { target: { value: "See HR " } });
   await new Promise((r) => setTimeout(r, 20));
   expect(box).toHaveValue("See Human Resources ");
-  const start = box.value.indexOf("Human Resources");
-  expect(box.selectionStart).toBe(start);
-  expect(box.selectionEnd).toBe(start + "Human Resources".length);
+  box.focus();
+  box.setSelectionRange(box.value.length, box.value.length);
   fireEvent.keyDown(box, { key: "Backspace" });
   expect(box).toHaveValue("See HR ");
 });
@@ -400,10 +400,9 @@ test("enter vs shift+enter", async () => {
   const select = await screen.findByRole("combobox");
   fireEvent.change(select, { target: { value: "idx" } });
   const box = screen.getByRole("textbox");
-  fireEvent.change(box, { target: { value: "line" } });
-  fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+  await userEvent.type(box, "line{Shift>}{Enter}{/Shift}");
   expect(box).toHaveValue("line\n");
 
-  fireEvent.keyDown(box, { key: "Enter" });
+  await userEvent.type(box, "{enter}");
   await waitFor(() => expect(fetchEventSource).toHaveBeenCalled());
 });

--- a/drsearch_frontend/package.json
+++ b/drsearch_frontend/package.json
@@ -50,6 +50,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/dompurify": "^3.0.5",
     "@types/jest": "^29.5.14",
     "jest": "^29.7.0",

--- a/drsearch_frontend/yarn.lock
+++ b/drsearch_frontend/yarn.lock
@@ -944,6 +944,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.53.1":
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.55.0.tgz#080fa6d9ee6d749ff523b1c18259572d0268b963"
+  integrity sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==
+  dependencies:
+    playwright "1.55.0"
+
 "@popperjs/core@^2.11.8":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -1018,6 +1025,11 @@
   integrity sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -2998,6 +3010,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
@@ -5003,6 +5020,20 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+playwright-core@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.55.0.tgz#ec8a9f8ef118afb3e86e0f46f1393e3bea32adf4"
+  integrity sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==
+
+playwright@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.55.0.tgz#7aca7ac3ffd9e083a8ad8b2514d6f9ba401cc78b"
+  integrity sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==
+  dependencies:
+    playwright-core "1.55.0"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
@@ -5602,6 +5633,7 @@ string-length@^4.0.1:
     strip-ansi "^6.0.0"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6306,6 +6338,7 @@ word-wrap@^1.2.5:
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Summary
- remove overlay-based AcronymTextarea
- introduce AutoResizeTextarea using native browser selection and caret
- update ChatWindow and tests; add @testing-library/user-event dev dependency

## Testing
- `yarn format`
- `yarn lint`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c3257755588325b22ee2b7e6c2ca89