### PR TITLE
Add guard rail for HTML context length

### DIFF
--- a/drsearch_backend/app/chain/formatter.py
+++ b/drsearch_backend/app/chain/formatter.py
@@ -1,8 +1,10 @@
-# file: app/chain/formatter.py
+"""Helpers to render retrieved documents into prompt-ready XML."""
 
 from __future__ import annotations
 
 from collections import OrderedDict
+from dataclasses import dataclass
+import logging
 from typing import Sequence
 
 from langchain_community.document_transformers import LongContextReorder
@@ -12,31 +14,131 @@ from app.chain.mapping import PartNumberMapping
 from app.core import chain_config
 
 
-class DocumentFormatter:
+logger = logging.getLogger(__name__)
+@dataclass
+class _FragmentState:
+    total_chars: int = 0
+    has_existing: bool = False
+
+
+class DocumentFormatter:  # pylint: disable=too-few-public-methods
     """Utility to pretty-print retrieved docs and enrich with UNC paths."""
 
-    def __init__(self, mapping: PartNumberMapping):
+    def __init__(self, mapping: PartNumberMapping, max_chars: int | None = None):
         self._mapping = mapping.data
         self._reorder = LongContextReorder() if chain_config.RAG_ON else None
+        limit = max_chars
+        if limit is None:
+            limit = chain_config.CONTEXT_CHAR_LIMIT
+        self._max_chars = limit if limit and limit > 0 else None
 
     def __call__(self, docs: Sequence[Document]) -> str:
         """Return prompt-ready <doc/> XML fragments."""
-        unique_map = OrderedDict()
-        for d in docs:
-            if d.page_content not in unique_map:
-                unique_map[d.page_content] = d
-        unique_docs = list(unique_map.values())
-        docs_reordered = (
-            self._reorder.transform_documents(unique_docs) if self._reorder else unique_docs
-        )
+        prepared_docs = self._prepare_documents(docs)
+        use_html = self._should_use_html(prepared_docs)
 
         formatted: list[str] = []
-        for idx, doc in enumerate(docs_reordered):
-            filename = doc.metadata.get("filename", "Unknown part number")
-            if self._mapping and filename in self._mapping:
-                doc.metadata["file_path"] = self._mapping[filename]
-
-            content = doc.metadata.get("text_as_html") or doc.page_content
-            formatted.append(f"<doc id='{idx}' source='{filename}'>{content}</doc>")
+        state = _FragmentState()
+        for idx, doc in enumerate(prepared_docs):
+            fragment, added_chars = self._render_fragment(
+                doc,
+                idx,
+                use_html=use_html,
+                state=state,
+            )
+            if fragment is None:
+                break
+            formatted.append(fragment)
+            state.total_chars += added_chars
+            state.has_existing = True
 
         return "\n".join(formatted)
+
+    def _prepare_documents(self, docs: Sequence[Document]) -> list[Document]:
+        """Deduplicate by content and reorder if enabled."""
+
+        unique_map = OrderedDict()
+        for doc in docs:
+            if doc.page_content not in unique_map:
+                unique_map[doc.page_content] = doc
+        unique_docs = list(unique_map.values())
+        return (
+            self._reorder.transform_documents(unique_docs)
+            if self._reorder
+            else unique_docs
+        )
+
+    def _should_use_html(self, docs: Sequence[Document]) -> bool:
+        if self._max_chars is None:
+            return True
+
+        html_chars = self._estimate_total_chars(docs, prefer_html=True)
+        if html_chars <= self._max_chars:
+            return True
+
+        logger.info(
+            "HTML context (%s chars) exceeds limit (%s); falling back to plain text",
+            html_chars,
+            self._max_chars,
+        )
+        return False
+
+    def _render_fragment(
+        self,
+        doc: Document,
+        idx: int,
+        *,
+        use_html: bool,
+        state: _FragmentState,
+    ) -> tuple[str | None, int]:
+        filename = doc.metadata.get("filename", "Unknown part number")
+        if self._mapping and filename in self._mapping:
+            doc.metadata["file_path"] = self._mapping[filename]
+
+        preferred = doc.metadata.get("text_as_html") if use_html else None
+        content = preferred or doc.page_content
+
+        prefix = f"<doc id='{idx}' source='{filename}'>"
+        suffix = "</doc>"
+        newline_overhead = 1 if state.has_existing else 0
+
+        if self._max_chars is not None:
+            remaining = self._max_chars - state.total_chars - newline_overhead
+            if remaining <= 0:
+                return None, 0
+
+            max_content = remaining - len(prefix) - len(suffix)
+            if max_content <= 0:
+                return None, 0
+
+            if len(content) > max_content:
+                content = content[:max_content]
+
+        fragment = f"{prefix}{content}{suffix}"
+        added_chars = len(fragment) + newline_overhead
+        return fragment, added_chars
+
+    @staticmethod
+    def _estimate_total_chars(
+        docs: Sequence[Document],
+        *,
+        prefer_html: bool,
+    ) -> int:
+        """Estimate the final number of characters if all docs were rendered."""
+
+        if not docs:
+            return 0
+
+        total = 0
+        for idx, doc in enumerate(docs):
+            filename = doc.metadata.get("filename", "Unknown part number")
+            prefix = f"<doc id='{idx}' source='{filename}'>"
+            suffix = "</doc>"
+            if prefer_html and doc.metadata.get("text_as_html"):
+                content = doc.metadata["text_as_html"]
+            else:
+                content = doc.page_content
+            total += len(prefix) + len(content) + len(suffix)
+
+        total += len(docs) - 1  # newline separators
+        return total

--- a/drsearch_backend/app/core/chain_config.py
+++ b/drsearch_backend/app/core/chain_config.py
@@ -37,6 +37,17 @@ _AZURE_SEARCH_KEY: str = os.getenv("AZURE_SEARCH_KEY", "")
 _NUMBER_OF_DOCS_RETRIEVED: int = 3
 
 
+#: Maximum number of characters that can be fed into the LLM as part of the
+#: retrieved context. Can be overridden via CONTEXT_CHAR_LIMIT. Setting the
+#: environment variable to "0" disables the guard rail.
+_context_char_limit_env = os.getenv("CONTEXT_CHAR_LIMIT")
+if _context_char_limit_env is None:
+    CONTEXT_CHAR_LIMIT: int | None = 12000
+else:
+    parsed_limit = max(int(_context_char_limit_env), 0)
+    CONTEXT_CHAR_LIMIT = parsed_limit or None
+
+
 #: Number of pages before and after a retrieved chunk to also fetch from
 #: the pgvector store. Setting to 0 preserves existing behaviour.
 _PAGE_WINDOW: int = int(os.getenv("PAGE_WINDOW", "0"))

--- a/drsearch_backend/tests/test_document_formatter.py
+++ b/drsearch_backend/tests/test_document_formatter.py
@@ -61,3 +61,36 @@ def test_formatter_prefers_html(monkeypatch):
     out = formatter(docs)
 
     assert out.startswith("<doc id='0' source='doc.html'>")
+
+
+def test_formatter_falls_back_to_plain_text_when_html_too_large(monkeypatch):
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", False)
+    mapping = PartNumberMapping(None)
+    doc = Document(
+        page_content="tiny",
+        metadata={"filename": "doc.html", "text_as_html": "<p>tiny</p>"},
+    )
+    prefix = "<doc id='0' source='doc.html'>"
+    suffix = "</doc>"
+    limit = len(prefix) + len(suffix) + len(doc.page_content)
+    formatter = DocumentFormatter(mapping, max_chars=limit)
+
+    out = formatter([doc])
+
+    assert "<p>tiny</p>" not in out
+    assert ">tiny</doc>" in out
+
+
+def test_formatter_truncates_when_plain_text_still_exceeds_limit(monkeypatch):
+    monkeypatch.setattr("app.core.chain_config.RAG_ON", False)
+    mapping = PartNumberMapping(None)
+    doc = Document(page_content="abcdefghij", metadata={"filename": "doc.txt"})
+    prefix = "<doc id='0' source='doc.txt'>"
+    suffix = "</doc>"
+    limit = len(prefix) + len(suffix) + 3
+    formatter = DocumentFormatter(mapping, max_chars=limit)
+
+    out = formatter([doc])
+
+    assert out.endswith("abc</doc>")
+    assert len(out) == limit


### PR DESCRIPTION
## Summary
- add a configurable CONTEXT_CHAR_LIMIT and teach DocumentFormatter to fall back to plain text or truncate when the rendered context would exceed that limit
- cover the new edge cases with regression tests for the formatter

## Testing
- `cd drsearch_backend && poetry run pytest tests/test_document_formatter.py`
- `cd drsearch_backend && poetry run pylint app/chain/formatter.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b6106563483258b22c6a8c6d557b4)